### PR TITLE
--multistream を指定しない場合は multistream をSora に送信しない

### DIFF
--- a/sdl_sample/src/sdl_sample.cpp
+++ b/sdl_sample/src/sdl_sample.cpp
@@ -5,6 +5,9 @@
 // CLI11
 #include <CLI/CLI.hpp>
 
+// Boost
+#include <boost/optional/optional_io.hpp>
+
 #include "sdl_renderer.h"
 
 #ifdef _WIN32
@@ -16,7 +19,7 @@ struct SDLSampleConfig : sora::SoraDefaultClientConfig {
   std::string channel_id;
   std::string role;
   std::string video_codec_type;
-  bool multistream = false;
+  boost::optional<bool> multistream;
   int width = 640;
   int height = 480;
   bool show_me = false;
@@ -140,8 +143,9 @@ int main(int argc, char* argv[]) {
 
   SDLSampleConfig config;
 
-  auto bool_map = std::vector<std::pair<std::string, bool>>(
-      {{"false", false}, {"true", true}});
+  auto optional_bool_map =
+    std::vector<std::pair<std::string, boost::optional<bool>>>(
+        {{"false", false}, {"true", true}, {"none", boost::none}});
 
   CLI::App app("SDL Sample for Sora C++ SDK");
   app.set_help_all_flag("--help-all",
@@ -164,8 +168,8 @@ int main(int argc, char* argv[]) {
                  "Video codec for send")
       ->check(CLI::IsMember({"", "VP8", "VP9", "AV1", "H264"}));
   app.add_option("--multistream", config.multistream,
-                 "Use multistream (default: false)")
-      ->transform(CLI::CheckedTransformer(bool_map, CLI::ignore_case));
+                 "Use multistream (default: none)")
+      ->transform(CLI::CheckedTransformer(optional_bool_map, CLI::ignore_case));
 
   // SDL に関するオプション
   app.add_option("--width", config.width, "SDL window width");


### PR DESCRIPTION
起動時のオプションに `--multistream` を指定しない場合、Sora とのシグナリングで `multistream : false` を Sora に送信していました。これを multistream の項目自体を送信しないように変更します。

今後、未指定時は Sora 側の `default_multistream` の設定に応じて動作するようになります。

以下のケースで動作確認をして想定通りの動作をしたことを確認しています。

- --multistream true
- --multistream false
- --multistream 未指定
 
めるぽんさんにアドバイスいただいて、 momo のソースを元に対応しました。ありがとうございました。