### PR TITLE
Github Actions にビルドエラー時の通知を追加する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,3 +133,25 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
+  notification:
+    name: Slack Notification
+    runs-on: ubuntu-latest
+    needs:
+      - build-windows
+      - build-macos
+      - build-ubuntu-2004
+      - build-ubuntu-2204
+    if: always()
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rtCamp/action-slack-notify@v2
+        if: |
+          needs.build-windows.result == 'failure' ||
+          needs.build-macos.result == 'failure' ||
+          needs.build-ubuntu-2004.result == 'failure' ||
+          needs.build-ubuntu-2204.result == 'failure'
+        env:
+          SLACK_CHANNEL: sora-cpp-sdk
+          SLACK_COLOR: danger
+          SLACK_TITLE: Failure build
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,12 +68,14 @@ jobs:
       - name: Install deps for Jetson series
         if: matrix.name == 'ubuntu-20.04_armv8_jetson'
         run: |
+          sudo apt update
           sudo apt install multistrap binutils-aarch64-linux-gnu
           # multistrap に insecure なリポジトリからの取得を許可する設定を入れる
           sudo sed -e 's/Apt::Get::AllowUnauthenticated=true/Apt::Get::AllowUnauthenticated=true";\n$config_str .= " -o Acquire::AllowInsecureRepositories=true/' -i /usr/sbin/multistrap
       - name: Install deps for Ubuntu x86_64
         if: matrix.name == 'ubuntu-20.04_x86_64'
         run: |
+          sudo apt update
           sudo apt install libdrm-dev libva-dev
       - run: python3 sdl_sample/${{ matrix.name }}/run.py
       - run: python3 momo_sample/${{ matrix.name }}/run.py
@@ -100,6 +102,7 @@ jobs:
       - name: Install deps for Ubuntu x86_64
         if: matrix.name == 'ubuntu-22.04_x86_64'
         run: |
+          sudo apt update
           sudo apt install libdrm-dev libva-dev
       - run: python3 sdl_sample/${{ matrix.name }}/run.py
       - run: python3 momo_sample/${{ matrix.name }}/run.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,15 +68,15 @@ jobs:
       - name: Install deps for Jetson series
         if: matrix.name == 'ubuntu-20.04_armv8_jetson'
         run: |
-          sudo apt update
-          sudo apt install multistrap binutils-aarch64-linux-gnu
+          sudo apt-get update
+          sudo apt-get install multistrap binutils-aarch64-linux-gnu
           # multistrap に insecure なリポジトリからの取得を許可する設定を入れる
           sudo sed -e 's/Apt::Get::AllowUnauthenticated=true/Apt::Get::AllowUnauthenticated=true";\n$config_str .= " -o Acquire::AllowInsecureRepositories=true/' -i /usr/sbin/multistrap
       - name: Install deps for Ubuntu x86_64
         if: matrix.name == 'ubuntu-20.04_x86_64'
         run: |
-          sudo apt update
-          sudo apt install libdrm-dev libva-dev
+          sudo apt-get update
+          sudo apt-get install libdrm-dev libva-dev
       - run: python3 sdl_sample/${{ matrix.name }}/run.py
       - run: python3 momo_sample/${{ matrix.name }}/run.py
       - name: Create Artifact
@@ -102,8 +102,8 @@ jobs:
       - name: Install deps for Ubuntu x86_64
         if: matrix.name == 'ubuntu-22.04_x86_64'
         run: |
-          sudo apt update
-          sudo apt install libdrm-dev libva-dev
+          sudo apt-get update
+          sudo apt-get install libdrm-dev libva-dev
       - run: python3 sdl_sample/${{ matrix.name }}/run.py
       - run: python3 momo_sample/${{ matrix.name }}/run.py
       - name: Create Artifact


### PR DESCRIPTION
Github Actions について以下 3 点を修正しています。
初めての修正なので確認していただけると助かります。

- ビルドが失敗した場合に Slack に通知をする
- apt を apt-get に変更する
  - Github Actions の実行ログにワーニングが出ていたため
- `apt-get install` の前に `apt-get update` を追加する
  - build-ubuntu-2204 でパッケージインストールのエラーが発生していたため

build-ubuntu-2204 でビルドエラーが発生していたため、Slack に通知が届くことは確認できています。