### PR TITLE
Sora のメッセージング機能の受信サンプルを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,13 @@ jobs:
       - uses: microsoft/setup-msbuild@v1.1
       - run: python3 sdl_sample/${{ matrix.name }}/run.py
       - run: python3 momo_sample/${{ matrix.name }}/run.py
+      - run: python3 messaging_recvonly_sample/${{ matrix.name }}/run.py
       - name: Create Artifact
         run: |
           mkdir ${{ matrix.name }}
           cp _build\${{ matrix.name }}\release\sdl_sample\Release\sdl_sample.exe ${{ matrix.name }}
           cp _build\${{ matrix.name }}\release\momo_sample\Release\momo_sample.exe ${{ matrix.name }}
+          cp _build\${{ matrix.name }}\release\messaging_recvonly_sample\Release\messaging_recvonly_sample.exe ${{ matrix.name }}
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -44,11 +46,13 @@ jobs:
       - uses: actions/checkout@v3
       - run: python3 sdl_sample/${{ matrix.name }}/run.py
       - run: python3 momo_sample/${{ matrix.name }}/run.py
+      - run: python3 messaging_recvonly_sample/${{ matrix.name }}/run.py
       - name: Create Artifact
         run: |
           mkdir ${{ matrix.name }}
           cp _build/${{ matrix.name }}/release/sdl_sample/sdl_sample ${{ matrix.name }}
           cp _build/${{ matrix.name }}/release/momo_sample/momo_sample ${{ matrix.name }}
+          cp _build/${{ matrix.name }}/release/messaging_recvonly_sample/messaging_recvonly_sample ${{ matrix.name }}
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -79,11 +83,13 @@ jobs:
           sudo apt-get install libdrm-dev libva-dev
       - run: python3 sdl_sample/${{ matrix.name }}/run.py
       - run: python3 momo_sample/${{ matrix.name }}/run.py
+      - run: python3 messaging_recvonly_sample/${{ matrix.name }}/run.py
       - name: Create Artifact
         run: |
           mkdir ${{ matrix.name }}
           cp _build/${{ matrix.name }}/release/sdl_sample/sdl_sample ${{ matrix.name }}
           cp _build/${{ matrix.name }}/release/momo_sample/momo_sample ${{ matrix.name }}
+          cp _build/${{ matrix.name }}/release/messaging_recvonly_sample/messaging_recvonly_sample ${{ matrix.name }}
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -106,11 +112,13 @@ jobs:
           sudo apt-get install libdrm-dev libva-dev
       - run: python3 sdl_sample/${{ matrix.name }}/run.py
       - run: python3 momo_sample/${{ matrix.name }}/run.py
+      - run: python3 messaging_recvonly_sample/${{ matrix.name }}/run.py
       - name: Create Artifact
         run: |
           mkdir ${{ matrix.name }}
           cp _build/${{ matrix.name }}/release/sdl_sample/sdl_sample ${{ matrix.name }}
           cp _build/${{ matrix.name }}/release/momo_sample/momo_sample ${{ matrix.name }}
+          cp _build/${{ matrix.name }}/release/messaging_recvonly_sample/messaging_recvonly_sample ${{ matrix.name }}
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ WebRTC SFU Sora と映像の送受信を行い、[SDL (Simple DirectMedia Layer)
 [WebRTC Native Client Momo](https://github.com/shiguredo/momo) の sora モードを模したサンプルです。
 使い方は [Momo サンプルを使ってみる](./doc/USE_MOMO_SAMPLE.md) をお読みください。
 
+### メッセージング受信サンプル
+
+WebRTC SFU Sora の [メッセージング機能](https://sora-doc.shiguredo.jp/MESSAGING) を使って送信されたメッセージを受信するサンプルです。
+使い方は [メッセージング受信サンプルを使ってみる](./doc/USE_MESSAGING_RECVONLY_SAMPLE.md) をお読みください。
+
 ## ライセンス
 
 Apache License 2.0
@@ -61,4 +66,3 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
-

--- a/doc/USE_MESSAGING_RECVONLY_SAMPLE.md
+++ b/doc/USE_MESSAGING_RECVONLY_SAMPLE.md
@@ -1,0 +1,192 @@
+# メッセージング受信サンプルを使ってみる
+
+## 概要
+
+[WebRTC SFU Sora](https://sora.shiguredo.jp/) の [メッセージング機能](https://sora-doc.shiguredo.jp/MESSAGING) を使って送信されたメッセージを受信して、標準出力にメッセージのラベルとデータサイズを表示するサンプルです。
+
+## 動作環境
+
+[動作環境](../README.md#動作環境) をご確認ください。
+
+接続先として WebRTC SFU Sora サーバ が必要です。[対応 Sora](../README.md#対応-sora) をご確認ください。
+
+## サンプルをビルドする
+
+以下にそれぞれのプラットフォームでのビルド方法を記載します。
+
+**ビルドに関しての問い合わせは受け付けておりません。うまくいかない場合は [GitHub Actions](https://github.com/shiguredo/sora-cpp-sdk-samples/blob/develop/.github/workflows/build.yml) の内容をご確認ください。**
+
+
+### リポジトリをクローンする
+
+[develop ブランチ](https://github.com/shiguredo/sora-cpp-sdk-samples.git) をクローンして利用してください。
+
+```shell
+$ git clone https://github.com/shiguredo/sora-cpp-sdk-samples.git
+$ cd sora-cpp-sdk-samples
+```
+
+### メッセージング受信サンプルをビルドする
+
+#### Windows x86_64 向けのビルドをする
+
+##### 事前準備
+
+以下のツールを準備してください。
+
+- [Visual Studio 2019](https://visualstudio.microsoft.com/ja/downloads/)
+    - C++ をビルドするためのコンポーネントを入れてください。
+- Python 3.10.5
+
+##### ビルド
+
+```powershell
+> python3 messaging_recvonly_sample\windows_x86_64\run.py
+```
+
+成功した場合、`_build\windows_x86_64\release\messaging_recvonly_sample\Release` に `messaging_recvonly_sample.exe` が作成されます。
+
+```
+\_BUILD\WINDOWS_X86_64\RELEASE\MESSAGING_RECVONLY_SAMPLE\RELEASE
+    messaging_recvonly_sample.exe
+```
+
+#### macOS arm64 向けのビルドをする
+
+##### 事前準備
+
+以下のツールを準備してください。
+
+- Python 3.9.13
+
+##### ビルド
+
+```shell
+$ python3 messaging_recvonly_sample/macos_arm64/run.py
+```
+
+成功した場合、`_build/macos_arm64/release/messaging_recvonly_sample` に `messaging_recvonly_sample` が作成されます。
+
+```
+_build/macos_arm64/release/messaging_recvonly_sample
+└── messaging_recvonly_sample
+```
+
+#### Ubuntu 20.04 x86_64 向けのビルドをする
+
+##### 事前準備
+
+必要なパッケージをインストールしてください。
+
+```shell
+$ sudo apt install libdrm-dev
+$ sudo apt install libva-dev
+$ sudo apt install pkg-config
+$ sudo apt install python3
+```
+
+##### ビルド
+
+```shell
+$ python3 messaging_recvonly_sample/ubuntu-20.04_x86_64/run.py
+```
+
+成功した場合、`_build/ubuntu-20.04_x86_64/release/messaging_recvonly_sample` に `messaging_recvonly_sample` が作成されます。
+
+```
+_build/ubuntu-20.04_x86_64/release/messaging_recvonly_sample/
+└── messaging_recvonly_sample
+```
+
+#### Ubuntu 22.04 x86_64 向けのビルドをする
+
+##### 事前準備
+
+必要なパッケージをインストールしてください。
+
+```shell
+$ sudo apt install libdrm-dev
+$ sudo apt install libva-dev
+$ sudo apt install pkg-config
+$ sudo apt install python3
+```
+
+##### ビルド
+
+```shell
+$ python3 messaging_recvonly_sample/ubuntu-22.04_x86_64/run.py
+```
+
+成功した場合、以下のファイルが作成されます。`_build/ubuntu-22.04_x86_64/release/messaging_recvonly_sample` に `messaging_recvonly_sample` が作成されます。
+
+```
+_build/ubuntu-22.04_x86_64/release/messaging_recvonly_sample/
+└── messaging_recvonly_sample
+```
+
+#### Ubuntu 20.04 x86_64 で Ubuntu 20.04 armv8 Jetson 向けのビルドをする
+
+**NVIDIA Jetson 上ではビルドできません。Ubuntu 20.04 x86_64 上でクロスコンパイルしたバイナリを利用するようにしてください。**
+
+##### 事前準備
+
+必要なパッケージをインストールしてください。
+
+```shell
+$ sudo apt install multistrap
+$ sudo apt install binutils-aarch64-linux-gnu
+$ sudo apt install python3
+```
+
+multistrap に insecure なリポジトリからの取得を許可する設定を行います。
+
+```shell
+$ sudo sed -e 's/Apt::Get::AllowUnauthenticated=true/Apt::Get::AllowUnauthenticated=true";\n$config_str .= " -o Acquire::AllowInsecureRepositories=true/' -i /usr/sbin/multistrap
+```
+
+##### ビルド
+
+```shell
+$ python3 messaging_recvonly_sample/ubuntu-20.04_armv8_jetson/run.py
+```
+
+成功した場合、以下のファイルが作成されます。`_build/ubuntu-20.04_armv8_jetson/release/messaging_recvonly_sample` に `messaging_recvonly_sample` が作成されます。
+
+```
+_build/ubuntu-20.04_armv8_jetson/release/messaging_recvonly_sample/
+└── messaging_recvonly_sample
+```
+
+## 実行する
+
+### コマンドラインから必要なオプションを指定して実行します
+
+ビルドされたバイナリのあるディレクトリに移動して、コマンドラインから必要なオプションを指定して実行します。
+以下は Sora サーバのシグナリング URL `wss://sora.example.com/signaling` の `sora` チャンネルに接続する例です。
+デフォルトでは `#sora-devtools` ラベルのメッセージが受信対象となります。
+
+Windows の場合
+```powershell
+> .\messaging_recvonly_sample.exe --signaling-url wss://sora.example.com/signaling --channel-id sora
+```
+
+Windows 以外の場合
+```shell
+$ ./messaging_recvonly_sample --signaling-url wss://sora.example.com/signaling --channel-id sora
+```
+
+#### Sora に関するオプション
+
+設定内容については [Sora のドキュメント](https://sora-doc.shiguredo.jp/SIGNALING) も参考にしてください。
+
+- `--signaling-url` : Sora サーバのシグナリング URL (必須)
+- `--channel-id` : channel_id (必須)
+    - 任意のチャンネル ID
+- `--data-channels` : 受信対象のデータチャネルのリストを JSON 形式で指定します
+    - 未指定の場合は `[{"label":"#sora-devtools", "direction":"recvonly"}]` が設定されます
+    - 指定可能な内容については Sora のドキュメントの ["type": "connect" 時の "data_channels"](https://develop.shiguredo-sora-doc.pages.dev/MESSAGING#8e04a8) を参照してください
+
+#### その他のオプション
+
+- `--help`
+    - ヘルプを表示します

--- a/doc/USE_MESSAGING_RECVONLY_SAMPLE.md
+++ b/doc/USE_MESSAGING_RECVONLY_SAMPLE.md
@@ -184,7 +184,7 @@ $ ./messaging_recvonly_sample --signaling-url wss://sora.example.com/signaling -
     - 任意のチャンネル ID
 - `--data-channels` : 受信対象のデータチャネルのリストを JSON 形式で指定します
     - 未指定の場合は `[{"label":"#sora-devtools", "direction":"recvonly"}]` が設定されます
-    - 指定可能な内容については Sora のドキュメントの ["type": "connect" 時の "data_channels"](https://develop.shiguredo-sora-doc.pages.dev/MESSAGING#8e04a8) を参照してください
+    - 指定可能な内容については Sora のドキュメントの ["type": "connect" 時の "data_channels"](https://sora-doc.shiguredo.jp/MESSAGING#8e04a8) を参照してください
 
 #### その他のオプション
 

--- a/messaging_recvonly_sample/macos_arm64/CMakeLists.txt
+++ b/messaging_recvonly_sample/macos_arm64/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.23)
+
+# Only interpret if() arguments as variables or keywords when unquoted.
+cmake_policy(SET CMP0054 NEW)
+# MSVC runtime library flags are selected by an abstraction.
+cmake_policy(SET CMP0091 NEW)
+
+set(WEBRTC_INCLUDE_DIR "" CACHE PATH "WebRTC のインクルードディレクトリ")
+set(WEBRTC_LIBRARY_DIR "" CACHE PATH "WebRTC のライブラリディレクトリ")
+set(WEBRTC_LIBRARY_NAME "webrtc" CACHE STRING "WebRTC のライブラリ名")
+set(BOOST_ROOT "" CACHE PATH "Boost のルートディレクトリ")
+set(SORA_DIR "" CACHE PATH "Sora のルートディレクトリ")
+set(CLI11_DIR "" CACHE PATH "CLI11 のルートディレクトリ")
+
+project(sora-messaging-recvonly-sample C CXX)
+
+list(APPEND CMAKE_PREFIX_PATH ${SORA_DIR})
+list(APPEND CMAKE_MODULE_PATH ${SORA_DIR}/share/cmake)
+
+set(Boost_USE_STATIC_LIBS ON)
+
+find_package(Boost REQUIRED COMPONENTS json)
+find_package(WebRTC REQUIRED)
+find_package(Sora REQUIRED)
+find_package(Threads REQUIRED)
+
+add_executable(messaging_recvonly_sample)
+set_target_properties(messaging_recvonly_sample PROPERTIES CXX_STANDARD 17 C_STANDARD 17)
+set_target_properties(messaging_recvonly_sample PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(messaging_recvonly_sample PROPERTIES CXX_VISIBILITY_PRESET hidden)
+target_sources(messaging_recvonly_sample PRIVATE ../src/messaging_recvonly_sample.cpp)
+
+target_include_directories(messaging_recvonly_sample PRIVATE ${CLI11_DIR}/include)
+target_link_libraries(messaging_recvonly_sample PRIVATE Sora::sora)
+target_compile_definitions(messaging_recvonly_sample PRIVATE CLI11_HAS_FILESYSTEM=0)

--- a/messaging_recvonly_sample/macos_arm64/run.py
+++ b/messaging_recvonly_sample/macos_arm64/run.py
@@ -1,0 +1,135 @@
+import os
+import multiprocessing
+import argparse
+import sys
+PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
+BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
+sys.path.insert(0, BASE_DIR)
+
+
+from base import (  # noqa
+    cd,
+    cmd,
+    cmdcap,
+    mkdir_p,
+    add_path,
+    cmake_path,
+    read_version_file,
+    get_webrtc_info,
+    install_webrtc,
+    install_boost,
+    install_cmake,
+    install_sora,
+    install_cli11,
+)
+
+
+def install_deps(source_dir, build_dir, install_dir, debug):
+    with cd(BASE_DIR):
+        version = read_version_file('VERSION')
+
+        # WebRTC
+        install_webrtc_args = {
+            'version': version['WEBRTC_BUILD_VERSION'],
+            'version_file': os.path.join(install_dir, 'webrtc.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'platform': 'macos_arm64',
+        }
+        install_webrtc(**install_webrtc_args)
+
+        sysroot = cmdcap(['xcrun', '--sdk', 'macosx', '--show-sdk-path'])
+
+        # Boost
+        install_boost_args = {
+            'version': version['BOOST_VERSION'],
+            'version_file': os.path.join(install_dir, 'boost.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'sora_version': version['SORA_CPP_SDK_VERSION'],
+            'platform': 'macos_arm64',
+        }
+        install_boost(**install_boost_args)
+
+        # CMake
+        install_cmake_args = {
+            'version': version['CMAKE_VERSION'],
+            'version_file': os.path.join(install_dir, 'cmake.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'platform': 'macos-universal',
+            'ext': 'tar.gz'
+        }
+        install_cmake(**install_cmake_args)
+        add_path(os.path.join(install_dir, 'cmake', 'CMake.app', 'Contents', 'bin'))
+
+        # Sora C++ SDK
+        install_sora_args = {
+            'version': version['SORA_CPP_SDK_VERSION'],
+            'version_file': os.path.join(install_dir, 'sora.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'platform': 'macos_arm64',
+        }
+        install_sora(**install_sora_args)
+
+        # CLI11
+        install_cli11_args = {
+            'version': version['CLI11_VERSION'],
+            'version_file': os.path.join(install_dir, 'cli11.version'),
+            'install_dir': install_dir,
+        }
+        install_cli11(**install_cli11_args)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--debug", action='store_true')
+
+    args = parser.parse_args()
+
+    configuration_dir = 'debug' if args.debug else 'release'
+    dir = 'macos_arm64'
+    source_dir = os.path.join(BASE_DIR, '_source', dir, configuration_dir)
+    build_dir = os.path.join(BASE_DIR, '_build', dir, configuration_dir)
+    install_dir = os.path.join(BASE_DIR, '_install', dir, configuration_dir)
+    mkdir_p(source_dir)
+    mkdir_p(build_dir)
+    mkdir_p(install_dir)
+
+    install_deps(source_dir, build_dir, install_dir, args.debug)
+
+    configuration = 'Debug' if args.debug else 'Release'
+
+    sample_build_dir = os.path.join(build_dir, 'messaging_recvonly_sample')
+    mkdir_p(sample_build_dir)
+    with cd(sample_build_dir):
+        webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+
+        cmake_args = []
+        cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
+        cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
+        cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
+
+        # クロスコンパイルの設定。
+        # 本来は toolchain ファイルに書く内容
+        sysroot = cmdcap(['xcrun', '--sdk', 'macosx', '--show-sdk-path'])
+        cmake_args += [
+            '-DCMAKE_SYSTEM_PROCESSOR=arm64',
+            '-DCMAKE_OSX_ARCHITECTURES=arm64',
+            "-DCMAKE_C_COMPILER=clang",
+            '-DCMAKE_C_COMPILER_TARGET=aarch64-apple-darwin',
+            "-DCMAKE_CXX_COMPILER=clang++",
+            '-DCMAKE_CXX_COMPILER_TARGET=aarch64-apple-darwin',
+            f'-DCMAKE_SYSROOT={sysroot}',
+        ]
+
+        cmd(['cmake', os.path.join(PROJECT_DIR)] + cmake_args)
+        cmd(['cmake', '--build', '.', f'-j{multiprocessing.cpu_count()}', '--config', configuration])
+
+
+if __name__ == '__main__':
+    main()

--- a/messaging_recvonly_sample/src/messaging_recvonly_sample.cpp
+++ b/messaging_recvonly_sample/src/messaging_recvonly_sample.cpp
@@ -52,11 +52,11 @@ class MessagingRecvOnlySample : public std::enable_shared_from_this<MessagingRec
       if (data_channel_object["compress"].is_bool()) {
         data_channel.compress = data_channel_object["compress"].as_bool();
       }
-      if (data_channel_object["max_packet_life_time"].is_int64()) {
-        data_channel.max_packet_life_time = data_channel_object["max_packet_life_time"].as_int64();
+      if (data_channel_object["max_packet_life_time"].is_number()) {
+        data_channel.max_packet_life_time = boost::json::value_to<int32_t>(data_channel_object["max_packet_life_time"]);
       }
-      if (data_channel_object["max_retransmits"].is_int64()) {
-        data_channel.max_retransmits = data_channel_object["max_retransmits"].as_int64();
+      if (data_channel_object["max_retransmits"].is_number()) {
+        data_channel.max_retransmits = boost::json::value_to<int32_t>(data_channel_object["max_retransmits"]);
       }
 
       config.data_channels.push_back(data_channel);

--- a/messaging_recvonly_sample/src/messaging_recvonly_sample.cpp
+++ b/messaging_recvonly_sample/src/messaging_recvonly_sample.cpp
@@ -82,7 +82,7 @@ class MessagingRecvOnlySample : public std::enable_shared_from_this<MessagingRec
   }
 
   void OnMessage(std::string label, std::string data) override {
-    RTC_LOG(LS_ERROR) << "OnMessage: [" << label << "] " << data;
+    RTC_LOG(LS_INFO) << "OnMessage: label=" << label << ", data=" << data.size() << " bytes";
   }
 
  private:

--- a/messaging_recvonly_sample/src/messaging_recvonly_sample.cpp
+++ b/messaging_recvonly_sample/src/messaging_recvonly_sample.cpp
@@ -1,0 +1,127 @@
+// Sora
+#include <sora/sora_default_client.h>
+
+// CLI11
+#include <CLI/CLI.hpp>
+
+// Boost
+#include <boost/optional/optional.hpp>
+
+#ifdef _WIN32
+#include <rtc_base/win/scoped_com_initializer.h>
+#endif
+
+struct MessagingRecvOnlySampleConfig : sora::SoraDefaultClientConfig {
+  std::string signaling_url;
+  std::string channel_id;
+};
+
+class MessagingRecvOnlySample : public std::enable_shared_from_this<MessagingRecvOnlySample>,
+                                public sora::SoraDefaultClient {
+ public:
+  MessagingRecvOnlySample(MessagingRecvOnlySampleConfig config)
+      : sora::SoraDefaultClient(config), config_(config) {}
+
+  void Run() {
+    ioc_.reset(new boost::asio::io_context(1));
+
+    sora::SoraSignalingConfig config;
+    config.pc_factory = factory();
+    config.io_context = ioc_.get();
+    config.observer = shared_from_this();
+    config.signaling_urls.push_back(config_.signaling_url);
+    config.channel_id = config_.channel_id;
+    config.role = "recvonly";
+    conn_ = sora::SoraSignaling::Create(config);
+
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type>
+        work_guard(ioc_->get_executor());
+
+    boost::asio::signal_set signals(*ioc_, SIGINT, SIGTERM);
+    signals.async_wait(
+        [this](const boost::system::error_code&, int) { conn_->Disconnect(); });
+
+    conn_->Connect();
+    ioc_->run();
+  }
+
+  void OnDisconnect(sora::SoraSignalingErrorCode ec,
+                    std::string message) override {
+    RTC_LOG(LS_INFO) << "OnDisconnect: " << message;
+    ioc_->stop();
+  }
+
+
+ private:
+  MessagingRecvOnlySampleConfig config_;
+  std::shared_ptr<sora::SoraSignaling> conn_;
+  std::unique_ptr<boost::asio::io_context> ioc_;
+};
+
+void add_optional_bool(CLI::App& app,
+                       const std::string& option_name,
+                       boost::optional<bool>& v,
+                       const std::string& help_text) {
+  auto f = [&v](const std::string& input) {
+    if (input == "true") {
+      v = true;
+    } else if (input == "false") {
+      v = false;
+    } else if (input == "none") {
+      v = boost::none;
+    } else {
+      throw CLI::ConversionError(input, "optional<bool>");
+    }
+  };
+  app.add_option_function<std::string>(option_name, f, help_text)
+      ->type_name("TEXT")
+      ->check(CLI::IsMember({"true", "false", "none"}));
+}
+
+int main(int argc, char* argv[]) {
+#ifdef _WIN32
+  webrtc::ScopedCOMInitializer com_initializer(
+      webrtc::ScopedCOMInitializer::kMTA);
+  if (!com_initializer.Succeeded()) {
+    std::cerr << "CoInitializeEx failed" << std::endl;
+    return 1;
+  }
+#endif
+
+  MessagingRecvOnlySampleConfig config;
+
+  CLI::App app("Messaging Recvonly Sample for Sora C++ SDK");
+  app.set_help_all_flag("--help-all",
+                        "Print help message for all modes and exit");
+
+  int log_level = (int)rtc::LS_ERROR;
+  auto log_level_map = std::vector<std::pair<std::string, int>>(
+      {{"verbose", 0}, {"info", 1}, {"warning", 2}, {"error", 3}, {"none", 4}});
+  app.add_option("--log-level", log_level, "Log severity level threshold")
+      ->transform(CLI::CheckedTransformer(log_level_map, CLI::ignore_case));
+
+  // Sora に関するオプション
+  app.add_option("--signaling-url", config.signaling_url, "Signaling URL")
+      ->required();
+  app.add_option("--channel-id", config.channel_id, "Channel ID")->required();
+
+  try {
+    app.parse(argc, argv);
+  } catch (const CLI::ParseError& e) {
+    exit(app.exit(e));
+  }
+
+  config.use_audio_device = false;
+  config.use_hardware_encoder = false;
+
+  if (log_level != rtc::LS_NONE) {
+    rtc::LogMessage::LogToDebug((rtc::LoggingSeverity)log_level);
+    rtc::LogMessage::LogTimestamps();
+    rtc::LogMessage::LogThreads();
+  }
+
+  auto sdlsample = sora::CreateSoraClient<MessagingRecvOnlySample>(config);
+  sdlsample->Run();
+
+  return 0;
+}

--- a/messaging_recvonly_sample/src/messaging_recvonly_sample.cpp
+++ b/messaging_recvonly_sample/src/messaging_recvonly_sample.cpp
@@ -82,7 +82,7 @@ class MessagingRecvOnlySample : public std::enable_shared_from_this<MessagingRec
   }
 
   void OnMessage(std::string label, std::string data) override {
-    RTC_LOG(LS_INFO) << "OnMessage: label=" << label << ", data=" << data.size() << " bytes";
+    std::cout << "OnMessage: label=" << label << ", data=" << data.size() << " bytes" << std::endl;
   }
 
  private:

--- a/messaging_recvonly_sample/ubuntu-20.04_armv8_jetson/CMakeLists.txt
+++ b/messaging_recvonly_sample/ubuntu-20.04_armv8_jetson/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.23)
+
+# Only interpret if() arguments as variables or keywords when unquoted.
+cmake_policy(SET CMP0054 NEW)
+# MSVC runtime library flags are selected by an abstraction.
+cmake_policy(SET CMP0091 NEW)
+
+set(WEBRTC_INCLUDE_DIR "" CACHE PATH "WebRTC のインクルードディレクトリ")
+set(WEBRTC_LIBRARY_DIR "" CACHE PATH "WebRTC のライブラリディレクトリ")
+set(WEBRTC_LIBRARY_NAME "webrtc" CACHE STRING "WebRTC のライブラリ名")
+set(BOOST_ROOT "" CACHE PATH "Boost のルートディレクトリ")
+set(SORA_DIR "" CACHE PATH "Sora のルートディレクトリ")
+set(CLI11_DIR "" CACHE PATH "CLI11 のルートディレクトリ")
+
+project(sora-sdl-sample C CXX)
+
+list(APPEND CMAKE_PREFIX_PATH ${SORA_DIR})
+list(APPEND CMAKE_MODULE_PATH ${SORA_DIR}/share/cmake)
+
+set(Boost_USE_STATIC_LIBS ON)
+
+find_package(Boost REQUIRED COMPONENTS json)
+find_package(WebRTC REQUIRED)
+find_package(Sora REQUIRED)
+find_package(Threads REQUIRED)
+
+add_executable(messaging_recvonly_sample)
+set_target_properties(messaging_recvonly_sample PROPERTIES CXX_STANDARD 17 C_STANDARD 17)
+set_target_properties(messaging_recvonly_sample PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_sources(messaging_recvonly_sample PRIVATE ../src/messaging_recvonly_sample.cpp)
+
+target_compile_options(messaging_recvonly_sample
+  PRIVATE
+    "$<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>"
+    "$<$<COMPILE_LANGUAGE:CXX>:-isystem${LIBCXX_INCLUDE_DIR}>"
+)
+target_include_directories(messaging_recvonly_sample PRIVATE ${CLI11_DIR}/include)
+target_link_libraries(messaging_recvonly_sample PRIVATE Sora::sora)
+target_link_directories(messaging_recvonly_sample PRIVATE ${CMAKE_SYSROOT}/usr/lib/aarch64-linux-gnu/tegra)
+target_compile_definitions(messaging_recvonly_sample PRIVATE CLI11_HAS_FILESYSTEM=0)

--- a/messaging_recvonly_sample/ubuntu-20.04_armv8_jetson/run.py
+++ b/messaging_recvonly_sample/ubuntu-20.04_armv8_jetson/run.py
@@ -1,0 +1,180 @@
+import os
+import multiprocessing
+import argparse
+import sys
+import hashlib
+PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
+BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
+sys.path.insert(0, BASE_DIR)
+
+
+from base import (  # noqa
+    cd,
+    cmd,
+    mkdir_p,
+    add_path,
+    cmake_path,
+    read_version_file,
+    get_webrtc_info,
+    install_rootfs,
+    install_webrtc,
+    install_llvm,
+    install_boost,
+    install_cmake,
+    install_sora,
+    install_cli11,
+)
+
+
+def install_deps(source_dir, build_dir, install_dir, debug):
+    with cd(BASE_DIR):
+        version = read_version_file('VERSION')
+
+        # multistrap を使った sysroot の構築
+        conf = os.path.join(BASE_DIR, 'multistrap', 'ubuntu-20.04_armv8_jetson.conf')
+        # conf ファイルのハッシュ値をバージョンとする
+        version_md5 = hashlib.md5(open(conf, 'rb').read()).hexdigest()
+        install_rootfs_args = {
+            'version': version_md5,
+            'version_file': os.path.join(install_dir, 'rootfs.version'),
+            'install_dir': install_dir,
+            'conf': conf,
+        }
+        install_rootfs(**install_rootfs_args)
+        sysroot = os.path.join(install_dir, 'rootfs')
+
+        # WebRTC
+        install_webrtc_args = {
+            'version': version['WEBRTC_BUILD_VERSION'],
+            'version_file': os.path.join(install_dir, 'webrtc.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'platform': 'ubuntu-20.04_armv8',
+        }
+        install_webrtc(**install_webrtc_args)
+
+        webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+        webrtc_version = read_version_file(webrtc_info.version_file)
+
+        # LLVM
+        tools_url = webrtc_version['WEBRTC_SRC_TOOLS_URL']
+        tools_commit = webrtc_version['WEBRTC_SRC_TOOLS_COMMIT']
+        libcxx_url = webrtc_version['WEBRTC_SRC_BUILDTOOLS_THIRD_PARTY_LIBCXX_TRUNK_URL']
+        libcxx_commit = webrtc_version['WEBRTC_SRC_BUILDTOOLS_THIRD_PARTY_LIBCXX_TRUNK_COMMIT']
+        buildtools_url = webrtc_version['WEBRTC_SRC_BUILDTOOLS_URL']
+        buildtools_commit = webrtc_version['WEBRTC_SRC_BUILDTOOLS_COMMIT']
+        install_llvm_args = {
+            'version':
+                f'{tools_url}.{tools_commit}.'
+                f'{libcxx_url}.{libcxx_commit}.'
+                f'{buildtools_url}.{buildtools_commit}',
+            'version_file': os.path.join(install_dir, 'llvm.version'),
+            'install_dir': install_dir,
+            'tools_url': tools_url,
+            'tools_commit': tools_commit,
+            'libcxx_url': libcxx_url,
+            'libcxx_commit': libcxx_commit,
+            'buildtools_url': buildtools_url,
+            'buildtools_commit': buildtools_commit,
+        }
+        install_llvm(**install_llvm_args)
+
+        # Boost
+        install_boost_args = {
+            'version': version['BOOST_VERSION'],
+            'version_file': os.path.join(install_dir, 'boost.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'sora_version': version['SORA_CPP_SDK_VERSION'],
+            'platform': 'ubuntu-20.04_armv8_jetson',
+        }
+        install_boost(**install_boost_args)
+
+        # CMake
+        install_cmake_args = {
+            'version': version['CMAKE_VERSION'],
+            'version_file': os.path.join(install_dir, 'cmake.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'platform': 'linux-x86_64',
+            'ext': 'tar.gz'
+        }
+        install_cmake(**install_cmake_args)
+        add_path(os.path.join(install_dir, 'cmake', 'bin'))
+
+        # Sora C++ SDK
+        install_sora_args = {
+            'version': version['SORA_CPP_SDK_VERSION'],
+            'version_file': os.path.join(install_dir, 'sora.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'platform': 'ubuntu-20.04_armv8_jetson',
+        }
+        install_sora(**install_sora_args)
+
+        # CLI11
+        install_cli11_args = {
+            'version': version['CLI11_VERSION'],
+            'version_file': os.path.join(install_dir, 'cli11.version'),
+            'install_dir': install_dir,
+        }
+        install_cli11(**install_cli11_args)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--debug", action='store_true')
+
+    args = parser.parse_args()
+
+    configuration_dir = 'debug' if args.debug else 'release'
+    dir = 'ubuntu-20.04_armv8_jetson'
+    source_dir = os.path.join(BASE_DIR, '_source', dir, configuration_dir)
+    build_dir = os.path.join(BASE_DIR, '_build', dir, configuration_dir)
+    install_dir = os.path.join(BASE_DIR, '_install', dir, configuration_dir)
+    mkdir_p(source_dir)
+    mkdir_p(build_dir)
+    mkdir_p(install_dir)
+
+    install_deps(source_dir, build_dir, install_dir, args.debug)
+
+    configuration = 'Debug' if args.debug else 'Release'
+
+    sample_build_dir = os.path.join(build_dir, 'messaging_recvonly_sample')
+    mkdir_p(sample_build_dir)
+    with cd(sample_build_dir):
+        webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+
+        cmake_args = []
+        cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
+        cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
+        cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
+
+        # クロスコンパイルの設定。
+        # 本来は toolchain ファイルに書く内容
+        sysroot = os.path.join(install_dir, 'rootfs')
+        cmake_args += [
+            '-DCMAKE_SYSTEM_NAME=Linux',
+            '-DCMAKE_SYSTEM_PROCESSOR=aarch64',
+            f"-DCMAKE_C_COMPILER={os.path.join(webrtc_info.clang_dir, 'bin', 'clang')}",
+            '-DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu',
+            f"-DCMAKE_CXX_COMPILER={os.path.join(webrtc_info.clang_dir, 'bin', 'clang++')}",
+            '-DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu',
+            f'-DCMAKE_FIND_ROOT_PATH={sysroot}',
+            '-DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER',
+            '-DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH',
+            '-DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH',
+            '-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH',
+            f'-DCMAKE_SYSROOT={sysroot}',
+            f"-DLIBCXX_INCLUDE_DIR={cmake_path(os.path.join(webrtc_info.libcxx_dir, 'include'))}",
+        ]
+
+        cmd(['cmake', os.path.join(PROJECT_DIR)] + cmake_args)
+        cmd(['cmake', '--build', '.', f'-j{multiprocessing.cpu_count()}', '--config', configuration])
+
+
+if __name__ == '__main__':
+    main()

--- a/messaging_recvonly_sample/ubuntu-20.04_x86_64/CMakeLists.txt
+++ b/messaging_recvonly_sample/ubuntu-20.04_x86_64/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.23)
+
+# Only interpret if() arguments as variables or keywords when unquoted.
+cmake_policy(SET CMP0054 NEW)
+# MSVC runtime library flags are selected by an abstraction.
+cmake_policy(SET CMP0091 NEW)
+
+set(WEBRTC_INCLUDE_DIR "" CACHE PATH "WebRTC のインクルードディレクトリ")
+set(WEBRTC_LIBRARY_DIR "" CACHE PATH "WebRTC のライブラリディレクトリ")
+set(WEBRTC_LIBRARY_NAME "webrtc" CACHE STRING "WebRTC のライブラリ名")
+set(BOOST_ROOT "" CACHE PATH "Boost のルートディレクトリ")
+set(SORA_DIR "" CACHE PATH "Sora のルートディレクトリ")
+set(CLI11_DIR "" CACHE PATH "CLI11 のルートディレクトリ")
+
+project(sora-messaging-recvonly-sample C CXX)
+
+list(APPEND CMAKE_PREFIX_PATH ${SORA_DIR})
+list(APPEND CMAKE_MODULE_PATH ${SORA_DIR}/share/cmake)
+
+set(Boost_USE_STATIC_LIBS ON)
+
+find_package(Boost REQUIRED COMPONENTS json)
+find_package(WebRTC REQUIRED)
+find_package(Sora REQUIRED)
+find_package(Threads REQUIRED)
+find_package(Libva REQUIRED)
+find_package(Libdrm REQUIRED)
+
+add_executable(messaging_recvonly_sample)
+set_target_properties(messaging_recvonly_sample PROPERTIES CXX_STANDARD 17 C_STANDARD 17)
+set_target_properties(messaging_recvonly_sample PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_sources(messaging_recvonly_sample PRIVATE ../src/messaging_recvonly_sample.cpp)
+
+target_compile_options(messaging_recvonly_sample
+  PRIVATE
+    "$<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>"
+    "$<$<COMPILE_LANGUAGE:CXX>:-isystem${LIBCXX_INCLUDE_DIR}>"
+)
+target_include_directories(messaging_recvonly_sample PRIVATE ${CLI11_DIR}/include)
+target_link_libraries(messaging_recvonly_sample PRIVATE Sora::sora)
+target_compile_definitions(messaging_recvonly_sample PRIVATE CLI11_HAS_FILESYSTEM=0)

--- a/messaging_recvonly_sample/ubuntu-20.04_x86_64/run.py
+++ b/messaging_recvonly_sample/ubuntu-20.04_x86_64/run.py
@@ -1,0 +1,154 @@
+import os
+import multiprocessing
+import argparse
+import sys
+PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
+BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
+sys.path.insert(0, BASE_DIR)
+
+
+from base import (  # noqa
+    cd,
+    cmd,
+    mkdir_p,
+    add_path,
+    cmake_path,
+    read_version_file,
+    get_webrtc_info,
+    install_webrtc,
+    install_llvm,
+    install_boost,
+    install_cmake,
+    install_sora,
+    install_cli11,
+)
+
+
+def install_deps(source_dir, build_dir, install_dir, debug):
+    with cd(BASE_DIR):
+        version = read_version_file('VERSION')
+
+        # WebRTC
+        install_webrtc_args = {
+            'version': version['WEBRTC_BUILD_VERSION'],
+            'version_file': os.path.join(install_dir, 'webrtc.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'platform': 'ubuntu-20.04_x86_64',
+        }
+        install_webrtc(**install_webrtc_args)
+
+        webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+        webrtc_version = read_version_file(webrtc_info.version_file)
+
+        # LLVM
+        tools_url = webrtc_version['WEBRTC_SRC_TOOLS_URL']
+        tools_commit = webrtc_version['WEBRTC_SRC_TOOLS_COMMIT']
+        libcxx_url = webrtc_version['WEBRTC_SRC_BUILDTOOLS_THIRD_PARTY_LIBCXX_TRUNK_URL']
+        libcxx_commit = webrtc_version['WEBRTC_SRC_BUILDTOOLS_THIRD_PARTY_LIBCXX_TRUNK_COMMIT']
+        buildtools_url = webrtc_version['WEBRTC_SRC_BUILDTOOLS_URL']
+        buildtools_commit = webrtc_version['WEBRTC_SRC_BUILDTOOLS_COMMIT']
+        install_llvm_args = {
+            'version':
+                f'{tools_url}.{tools_commit}.'
+                f'{libcxx_url}.{libcxx_commit}.'
+                f'{buildtools_url}.{buildtools_commit}',
+            'version_file': os.path.join(install_dir, 'llvm.version'),
+            'install_dir': install_dir,
+            'tools_url': tools_url,
+            'tools_commit': tools_commit,
+            'libcxx_url': libcxx_url,
+            'libcxx_commit': libcxx_commit,
+            'buildtools_url': buildtools_url,
+            'buildtools_commit': buildtools_commit,
+        }
+        install_llvm(**install_llvm_args)
+
+        # Boost
+        install_boost_args = {
+            'version': version['BOOST_VERSION'],
+            'version_file': os.path.join(install_dir, 'boost.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'sora_version': version['SORA_CPP_SDK_VERSION'],
+            'platform': 'ubuntu-20.04_x86_64',
+        }
+        install_boost(**install_boost_args)
+
+        # CMake
+        install_cmake_args = {
+            'version': version['CMAKE_VERSION'],
+            'version_file': os.path.join(install_dir, 'cmake.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'platform': 'linux-x86_64',
+            'ext': 'tar.gz'
+        }
+        install_cmake(**install_cmake_args)
+        add_path(os.path.join(install_dir, 'cmake', 'bin'))
+
+        # Sora C++ SDK
+        install_sora_args = {
+            'version': version['SORA_CPP_SDK_VERSION'],
+            'version_file': os.path.join(install_dir, 'sora.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'platform': 'ubuntu-20.04_x86_64',
+        }
+        install_sora(**install_sora_args)
+
+        # CLI11
+        install_cli11_args = {
+            'version': version['CLI11_VERSION'],
+            'version_file': os.path.join(install_dir, 'cli11.version'),
+            'install_dir': install_dir,
+        }
+        install_cli11(**install_cli11_args)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--debug", action='store_true')
+
+    args = parser.parse_args()
+
+    configuration_dir = 'debug' if args.debug else 'release'
+    dir = 'ubuntu-20.04_x86_64'
+    source_dir = os.path.join(BASE_DIR, '_source', dir, configuration_dir)
+    build_dir = os.path.join(BASE_DIR, '_build', dir, configuration_dir)
+    install_dir = os.path.join(BASE_DIR, '_install', dir, configuration_dir)
+    mkdir_p(source_dir)
+    mkdir_p(build_dir)
+    mkdir_p(install_dir)
+
+    install_deps(source_dir, build_dir, install_dir, args.debug)
+
+    configuration = 'Debug' if args.debug else 'Release'
+
+    sample_build_dir = os.path.join(build_dir, 'messaging_recvonly_sample')
+    mkdir_p(sample_build_dir)
+    with cd(sample_build_dir):
+        webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+
+        cmake_args = []
+        cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
+        cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
+        cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
+
+        # クロスコンパイルの設定。
+        # 本来は toolchain ファイルに書く内容
+        cmake_args += [
+            f"-DCMAKE_C_COMPILER={os.path.join(webrtc_info.clang_dir, 'bin', 'clang')}",
+            f"-DCMAKE_CXX_COMPILER={os.path.join(webrtc_info.clang_dir, 'bin', 'clang++')}",
+            f"-DLIBCXX_INCLUDE_DIR={cmake_path(os.path.join(webrtc_info.libcxx_dir, 'include'))}",
+        ]
+
+        cmd(['cmake', os.path.join(PROJECT_DIR)] + cmake_args)
+        cmd(['cmake', '--build', '.', f'-j{multiprocessing.cpu_count()}', '--config', configuration])
+
+
+if __name__ == '__main__':
+    main()

--- a/messaging_recvonly_sample/ubuntu-22.04_x86_64/CMakeLists.txt
+++ b/messaging_recvonly_sample/ubuntu-22.04_x86_64/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.23)
+
+# Only interpret if() arguments as variables or keywords when unquoted.
+cmake_policy(SET CMP0054 NEW)
+# MSVC runtime library flags are selected by an abstraction.
+cmake_policy(SET CMP0091 NEW)
+
+set(WEBRTC_INCLUDE_DIR "" CACHE PATH "WebRTC のインクルードディレクトリ")
+set(WEBRTC_LIBRARY_DIR "" CACHE PATH "WebRTC のライブラリディレクトリ")
+set(WEBRTC_LIBRARY_NAME "webrtc" CACHE STRING "WebRTC のライブラリ名")
+set(BOOST_ROOT "" CACHE PATH "Boost のルートディレクトリ")
+set(SORA_DIR "" CACHE PATH "Sora のルートディレクトリ")
+set(CLI11_DIR "" CACHE PATH "CLI11 のルートディレクトリ")
+
+project(sora-sdl-sample C CXX)
+
+list(APPEND CMAKE_PREFIX_PATH ${SORA_DIR})
+list(APPEND CMAKE_MODULE_PATH ${SORA_DIR}/share/cmake)
+
+set(Boost_USE_STATIC_LIBS ON)
+
+find_package(Boost REQUIRED COMPONENTS json)
+find_package(WebRTC REQUIRED)
+find_package(Sora REQUIRED)
+find_package(Threads REQUIRED)
+find_package(Libva REQUIRED)
+find_package(Libdrm REQUIRED)
+
+add_executable(messaging_recvonly_sample)
+set_target_properties(messaging_recvonly_sample PROPERTIES CXX_STANDARD 17 C_STANDARD 17)
+set_target_properties(messaging_recvonly_sample PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_sources(messaging_recvonly_sample PRIVATE ../src/messaging_recvonly_sample.cpp)
+
+target_compile_options(messaging_recvonly_sample
+  PRIVATE
+    "$<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>"
+    "$<$<COMPILE_LANGUAGE:CXX>:-isystem${LIBCXX_INCLUDE_DIR}>"
+)
+target_include_directories(messaging_recvonly_sample PRIVATE ${CLI11_DIR}/include)
+target_link_libraries(messaging_recvonly_sample PRIVATE Sora::sora)
+target_compile_definitions(messaging_recvonly_sample PRIVATE CLI11_HAS_FILESYSTEM=0)

--- a/messaging_recvonly_sample/ubuntu-22.04_x86_64/run.py
+++ b/messaging_recvonly_sample/ubuntu-22.04_x86_64/run.py
@@ -1,0 +1,154 @@
+import os
+import multiprocessing
+import argparse
+import sys
+PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
+BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
+sys.path.insert(0, BASE_DIR)
+
+
+from base import (  # noqa
+    cd,
+    cmd,
+    mkdir_p,
+    add_path,
+    cmake_path,
+    read_version_file,
+    get_webrtc_info,
+    install_webrtc,
+    install_llvm,
+    install_boost,
+    install_cmake,
+    install_sora,
+    install_cli11,
+)
+
+
+def install_deps(source_dir, build_dir, install_dir, debug):
+    with cd(BASE_DIR):
+        version = read_version_file('VERSION')
+
+        # WebRTC
+        install_webrtc_args = {
+            'version': version['WEBRTC_BUILD_VERSION'],
+            'version_file': os.path.join(install_dir, 'webrtc.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'platform': 'ubuntu-22.04_x86_64',
+        }
+        install_webrtc(**install_webrtc_args)
+
+        webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+        webrtc_version = read_version_file(webrtc_info.version_file)
+
+        # LLVM
+        tools_url = webrtc_version['WEBRTC_SRC_TOOLS_URL']
+        tools_commit = webrtc_version['WEBRTC_SRC_TOOLS_COMMIT']
+        libcxx_url = webrtc_version['WEBRTC_SRC_BUILDTOOLS_THIRD_PARTY_LIBCXX_TRUNK_URL']
+        libcxx_commit = webrtc_version['WEBRTC_SRC_BUILDTOOLS_THIRD_PARTY_LIBCXX_TRUNK_COMMIT']
+        buildtools_url = webrtc_version['WEBRTC_SRC_BUILDTOOLS_URL']
+        buildtools_commit = webrtc_version['WEBRTC_SRC_BUILDTOOLS_COMMIT']
+        install_llvm_args = {
+            'version':
+                f'{tools_url}.{tools_commit}.'
+                f'{libcxx_url}.{libcxx_commit}.'
+                f'{buildtools_url}.{buildtools_commit}',
+            'version_file': os.path.join(install_dir, 'llvm.version'),
+            'install_dir': install_dir,
+            'tools_url': tools_url,
+            'tools_commit': tools_commit,
+            'libcxx_url': libcxx_url,
+            'libcxx_commit': libcxx_commit,
+            'buildtools_url': buildtools_url,
+            'buildtools_commit': buildtools_commit,
+        }
+        install_llvm(**install_llvm_args)
+
+        # Boost
+        install_boost_args = {
+            'version': version['BOOST_VERSION'],
+            'version_file': os.path.join(install_dir, 'boost.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'sora_version': version['SORA_CPP_SDK_VERSION'],
+            'platform': 'ubuntu-22.04_x86_64',
+        }
+        install_boost(**install_boost_args)
+
+        # CMake
+        install_cmake_args = {
+            'version': version['CMAKE_VERSION'],
+            'version_file': os.path.join(install_dir, 'cmake.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'platform': 'linux-x86_64',
+            'ext': 'tar.gz'
+        }
+        install_cmake(**install_cmake_args)
+        add_path(os.path.join(install_dir, 'cmake', 'bin'))
+
+        # Sora C++ SDK
+        install_sora_args = {
+            'version': version['SORA_CPP_SDK_VERSION'],
+            'version_file': os.path.join(install_dir, 'sora.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'platform': 'ubuntu-22.04_x86_64',
+        }
+        install_sora(**install_sora_args)
+
+        # CLI11
+        install_cli11_args = {
+            'version': version['CLI11_VERSION'],
+            'version_file': os.path.join(install_dir, 'cli11.version'),
+            'install_dir': install_dir,
+        }
+        install_cli11(**install_cli11_args)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--debug", action='store_true')
+
+    args = parser.parse_args()
+
+    configuration_dir = 'debug' if args.debug else 'release'
+    dir = 'ubuntu-22.04_x86_64'
+    source_dir = os.path.join(BASE_DIR, '_source', dir, configuration_dir)
+    build_dir = os.path.join(BASE_DIR, '_build', dir, configuration_dir)
+    install_dir = os.path.join(BASE_DIR, '_install', dir, configuration_dir)
+    mkdir_p(source_dir)
+    mkdir_p(build_dir)
+    mkdir_p(install_dir)
+
+    install_deps(source_dir, build_dir, install_dir, args.debug)
+
+    configuration = 'Debug' if args.debug else 'Release'
+
+    sample_build_dir = os.path.join(build_dir, 'messaging_recvonly_sample')
+    mkdir_p(sample_build_dir)
+    with cd(sample_build_dir):
+        webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+
+        cmake_args = []
+        cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
+        cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
+        cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
+
+        # クロスコンパイルの設定。
+        # 本来は toolchain ファイルに書く内容
+        cmake_args += [
+            f"-DCMAKE_C_COMPILER={os.path.join(webrtc_info.clang_dir, 'bin', 'clang')}",
+            f"-DCMAKE_CXX_COMPILER={os.path.join(webrtc_info.clang_dir, 'bin', 'clang++')}",
+            f"-DLIBCXX_INCLUDE_DIR={cmake_path(os.path.join(webrtc_info.libcxx_dir, 'include'))}",
+        ]
+
+        cmd(['cmake', os.path.join(PROJECT_DIR)] + cmake_args)
+        cmd(['cmake', '--build', '.', f'-j{multiprocessing.cpu_count()}', '--config', configuration])
+
+
+if __name__ == '__main__':
+    main()

--- a/messaging_recvonly_sample/windows_x86_64/CMakeLists.txt
+++ b/messaging_recvonly_sample/windows_x86_64/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.23)
+
+# Only interpret if() arguments as variables or keywords when unquoted.
+cmake_policy(SET CMP0054 NEW)
+# MSVC runtime library flags are selected by an abstraction.
+cmake_policy(SET CMP0091 NEW)
+
+set(WEBRTC_INCLUDE_DIR "" CACHE PATH "WebRTC のインクルードディレクトリ")
+set(WEBRTC_LIBRARY_DIR "" CACHE PATH "WebRTC のライブラリディレクトリ")
+set(WEBRTC_LIBRARY_NAME "webrtc" CACHE STRING "WebRTC のライブラリ名")
+set(BOOST_ROOT "" CACHE PATH "Boost のルートディレクトリ")
+set(SORA_DIR "" CACHE PATH "Sora のルートディレクトリ")
+set(CLI11_DIR "" CACHE PATH "CLI11 のルートディレクトリ")
+
+project(sora-messaging-recvonly-sample C CXX)
+
+list(APPEND CMAKE_PREFIX_PATH ${SORA_DIR})
+list(APPEND CMAKE_MODULE_PATH ${SORA_DIR}/share/cmake)
+
+set(Boost_USE_STATIC_LIBS ON)
+set(Boost_USE_STATIC_RUNTIME ON)
+
+find_package(Boost REQUIRED COMPONENTS json)
+find_package(WebRTC REQUIRED)
+find_package(Sora REQUIRED)
+
+add_executable(messaging_recvonly_sample)
+set_target_properties(messaging_recvonly_sample PROPERTIES CXX_STANDARD 17 C_STANDARD 17)
+set_target_properties(messaging_recvonly_sample PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_sources(messaging_recvonly_sample PRIVATE ../src/messaging_recvonly_sample.cpp)
+
+target_include_directories(messaging_recvonly_sample PRIVATE ${CLI11_DIR}/include)
+target_link_libraries(messaging_recvonly_sample PRIVATE Sora::sora)
+
+# 文字コードを utf-8 として扱うのと、シンボルテーブル数を増やす
+target_compile_options(messaging_recvonly_sample PRIVATE /utf-8 /bigobj)
+set_target_properties(messaging_recvonly_sample
+  PROPERTIES
+    # CRTライブラリを静的リンクさせる
+    MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+)
+
+target_compile_definitions(messaging_recvonly_sample
+  PRIVATE
+    _CONSOLE
+    _WIN32_WINNT=0x0A00
+    NOMINMAX
+    WIN32_LEAN_AND_MEAN
+    CLI11_HAS_FILESYSTEM=0
+)

--- a/messaging_recvonly_sample/windows_x86_64/run.py
+++ b/messaging_recvonly_sample/windows_x86_64/run.py
@@ -1,0 +1,120 @@
+import os
+import multiprocessing
+import argparse
+import sys
+PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
+BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
+sys.path.insert(0, BASE_DIR)
+
+
+from base import (  # noqa
+    cd,
+    cmd,
+    mkdir_p,
+    add_path,
+    cmake_path,
+    read_version_file,
+    get_webrtc_info,
+    install_webrtc,
+    install_boost,
+    install_cmake,
+    install_sora,
+    install_cli11,
+)
+
+
+def install_deps(source_dir, build_dir, install_dir, debug):
+    with cd(BASE_DIR):
+        version = read_version_file('VERSION')
+
+        # WebRTC
+        install_webrtc_args = {
+            'version': version['WEBRTC_BUILD_VERSION'],
+            'version_file': os.path.join(install_dir, 'webrtc.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'platform': 'windows_x86_64',
+        }
+
+        install_webrtc(**install_webrtc_args)
+
+        # Boost
+        install_boost_args = {
+            'version': version['BOOST_VERSION'],
+            'version_file': os.path.join(install_dir, 'boost.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'sora_version': version['SORA_CPP_SDK_VERSION'],
+            'platform': 'windows_x86_64',
+        }
+        install_boost(**install_boost_args)
+
+        # CMake
+        install_cmake_args = {
+            'version': version['CMAKE_VERSION'],
+            'version_file': os.path.join(install_dir, 'cmake.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'platform': 'windows-x86_64',
+            'ext': 'zip'
+        }
+        install_cmake(**install_cmake_args)
+
+        add_path(os.path.join(install_dir, 'cmake', 'bin'))
+
+        # Sora C++ SDK
+        install_sora_args = {
+            'version': version['SORA_CPP_SDK_VERSION'],
+            'version_file': os.path.join(install_dir, 'sora.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'platform': 'windows_x86_64',
+        }
+        install_sora(**install_sora_args)
+
+        # CLI11
+        install_cli11_args = {
+            'version': version['CLI11_VERSION'],
+            'version_file': os.path.join(install_dir, 'cli11.version'),
+            'install_dir': install_dir,
+        }
+        install_cli11(**install_cli11_args)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--debug", action='store_true')
+
+    args = parser.parse_args()
+
+    configuration_dir = 'debug' if args.debug else 'release'
+    dir = 'windows_x86_64'
+    source_dir = os.path.join(BASE_DIR, '_source', dir, configuration_dir)
+    build_dir = os.path.join(BASE_DIR, '_build', dir, configuration_dir)
+    install_dir = os.path.join(BASE_DIR, '_install', dir, configuration_dir)
+    mkdir_p(source_dir)
+    mkdir_p(build_dir)
+    mkdir_p(install_dir)
+
+    install_deps(source_dir, build_dir, install_dir, args.debug)
+
+    configuration = 'Debug' if args.debug else 'Release'
+
+    sample_build_dir = os.path.join(build_dir, 'messaging_recvonly_sample')
+    mkdir_p(sample_build_dir)
+    with cd(sample_build_dir):
+        webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+
+        cmake_args = []
+        cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
+        cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
+        cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
+        cmd(['cmake', os.path.join(PROJECT_DIR)] + cmake_args)
+        cmd(['cmake', '--build', '.', f'-j{multiprocessing.cpu_count()}', '--config', configuration])
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
タイトルの通りのサンプルを追加する PR です。

実行例:
```
$ messaging_recvonly_sample --signaling-url ws://localhost:5000/signaling \
                            --channel-id sora \
                            --data-channels '[{"label":"#sora-devtools"}]'

# メッセージを受信するたびに、以下のように標準出力に表示される
OnMessage: label=#sora-devtools, data=5 bytes
```

追加ファイルのほとんどは「SDL サンプルをコピーして SDL 関連部分を削除および名前の置換(`s/sdl/messaging_recvonly/`)」を行っただけのものとなっています（そうではない差分については PR コメントを残していいます）。