### PR TITLE
momo サンプルに resolution オプションを追加

### DIFF
--- a/doc/USE_MOMO_SAMPLE.md
+++ b/doc/USE_MOMO_SAMPLE.md
@@ -173,6 +173,14 @@ Windows 以外の場合
 $ ./momo_sample --signaling-url wss://sora.example.com/signaling --role sendrecv --channel-id sora --multistream true --use-sdl
 ```
 
+#### Momo Sample 実行に関するオプション
+
+- `--log-level` : 実行時にターミナルに出力するログのレベル
+    - `verbose->0,info->1,warning->2,error->3,none->4` の値が指定可能です
+- `--resolution` : 映像配信する際の解像度
+    - 解像度は `QVGA, VGA, HD, FHD, 4K, or [WIDTH]x[HEIGHT]` の値が指定可能です
+    - 未指定の場合は `HD` が設定されます
+
 #### Sora に関するオプション
 
 設定内容については [Sora のドキュメント](https://sora-doc.shiguredo.jp/SIGNALING) も参考にしてください。

--- a/doc/USE_MOMO_SAMPLE.md
+++ b/doc/USE_MOMO_SAMPLE.md
@@ -173,22 +173,25 @@ Windows 以外の場合
 $ ./momo_sample --signaling-url wss://sora.example.com/signaling --role sendrecv --channel-id sora --multistream true --use-sdl
 ```
 
+#### 必須オプション
+
+- `--signaling-url` : Sora サーバのシグナリング URL (必須)
+- `--channel-id` : [channel_id](https://sora-doc.shiguredo.jp/SIGNALING#ee30e9) (必須)
+- `--role` : [role](https://sora-doc.shiguredo.jp/SIGNALING#6d21b9) (必須)
+    - sendrecv / sendonly / recvonly のいずれかを指定
+
 #### Momo Sample 実行に関するオプション
 
 - `--log-level` : 実行時にターミナルに出力するログのレベル
     - `verbose->0,info->1,warning->2,error->3,none->4` の値が指定可能です
 - `--resolution` : 映像配信する際の解像度
     - 解像度は `QVGA, VGA, HD, FHD, 4K, or [WIDTH]x[HEIGHT]` の値が指定可能です
-    - 未指定の場合は `HD` が設定されます
+    - 未指定の場合は `VGA` が設定されます
 
 #### Sora に関するオプション
 
 設定内容については [Sora のドキュメント](https://sora-doc.shiguredo.jp/SIGNALING) も参考にしてください。
 
-- `--signaling-url` : Sora サーバのシグナリング URL (必須)
-- `--channel-id` : [channel_id](https://sora-doc.shiguredo.jp/SIGNALING#ee30e9) (必須)
-- `--role` : [role](https://sora-doc.shiguredo.jp/SIGNALING#6d21b9) (必須)
-    - sendrecv / sendonly / recvonly のいずれかを指定
 - `--client-id` : [client_id](https://sora-doc.shiguredo.jp/SIGNALING#d00933) 
 - `--video` : 映像の利用 (true/false)
     - 未指定の場合は true が設定されます

--- a/momo_sample/src/momo_sample.cpp
+++ b/momo_sample/src/momo_sample.cpp
@@ -23,6 +23,7 @@ struct MomoSampleConfig : sora::SoraDefaultClientConfig {
   bool audio = true;
   std::string video_codec_type;
   std::string audio_codec_type;
+  std::string resolution = "VGA";
   int video_bit_rate = 0;
   int audio_bit_rate = 0;
   boost::json::value metadata;
@@ -42,6 +43,34 @@ struct MomoSampleConfig : sora::SoraDefaultClientConfig {
   int window_height = 480;
   bool show_me = false;
   bool fullscreen = false;
+
+  struct Size {
+    int width;
+    int height;
+  };
+
+  Size GetSize() {
+    if (resolution == "QVGA") {
+      return {320, 240};
+    } else if (resolution == "VGA") {
+      return {640, 480};
+    } else if (resolution == "HD") {
+      return {1280, 720};
+    } else if (resolution == "FHD") {
+      return {1920, 1080};
+    } else if (resolution == "4K") {
+      return {3840, 2160};
+    }
+
+    // 数字で指定した場合の処理 (例 640x480 )
+    auto pos = resolution.find('x');
+    if (pos == std::string::npos) {
+      return {16, 16};
+    }
+    auto width = std::atoi(resolution.substr(0, pos).c_str());
+    auto height = std::atoi(resolution.substr(pos + 1).c_str());
+    return {std::max(16, width), std::max(16, height)};
+  }
 };
 
 class MomoSample : public std::enable_shared_from_this<MomoSample>,
@@ -56,10 +85,11 @@ class MomoSample : public std::enable_shared_from_this<MomoSample>,
           config_.window_width, config_.window_height, config_.fullscreen));
     }
 
+    auto size = config_.GetSize();
     if (config_.role != "recvonly") {
       sora::CameraDeviceCapturerConfig cam_config;
-      cam_config.width = 640;
-      cam_config.height = 480;
+      cam_config.width = size.width;
+      cam_config.height = size.height;
       cam_config.fps = 30;
       auto video_source = sora::CreateCameraDeviceCapturer(cam_config);
       if (video_source == nullptr) {
@@ -233,6 +263,9 @@ int main(int argc, char* argv[]) {
       {{"verbose", 0}, {"info", 1}, {"warning", 2}, {"error", 3}, {"none", 4}});
   app.add_option("--log-level", log_level, "Log severity level threshold")
       ->transform(CLI::CheckedTransformer(log_level_map, CLI::ignore_case));
+  app.add_option("--resolution", config.resolution,
+                 "Video resolution (one of QVGA, VGA, HD, FHD, 4K, or "
+                 "[WIDTH]x[HEIGHT])");
 
   // Sora に関するオプション
   app.add_option("--signaling-url", config.signaling_url, "Signaling URL")


### PR DESCRIPTION
momo サンプルに resolution オプションを追加しました。
macOS arm64 でローカルビルドを実行し、動作を確認しました。