### PR TITLE
CHANGES.md を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,55 @@
+# 変更履歴
+
+- CHANGE
+    - 下位互換のない変更
+- UPDATE
+    - 下位互換がある変更
+- ADD
+    - 下位互換がある追加
+- FIX
+    - バグ修正
+
+## develop
+
+## sora-cpp-sdk-2023.6.0
+
+- [UPDATE] Sora CPP SDK を 2023.6.0 にあげる
+    - @miosakuma
+- [UPDATE] WEBRTC_BUILD_VERSION を m114.5735.2.0 にあげる
+    - @miosakuma
+- [ADD] Windows の momo_sample に --relwithdebinfo オプションを追加する
+    - @melpon
+
+## sora-cpp-sdk-2023.5.1
+
+- [UPDATE] Sora CPP SDK を 2023.5.1 にあげる
+    - @miosakuma
+
+## sora-cpp-sdk-2023.5.0
+
+- [CHANGE] SoraDefaultClient を削除して SoraClientContext を追加する
+    - @melpon
+- [UPDATE] JetPack 5.1 に対応する
+    - @melpon
+- [UPDATE] VERSIONS のライブラリをアップデートする
+    - SORA_CPP_SDK_VERSION を 2023.5.0 にあげる
+    - WEBRTC_BUILD_VERSION を m114.5735.0.1 にあげる
+    - BOOST_VERSION を 1.82.0 にあげる
+    - CMAKE_VERSION を 3.25.0 にあげる
+    - SDL2_VERSION を 2.26.5 にあげる
+    - CLI11_VERSION を 2.3.2 にあげる
+    - @miosakuma
+- [UPDATE] CXX_STANDARD を 20 にあげる
+    - @miosakuma
+- [ADD] デバイス一覧を取得する機能追加する
+    - @melpon
+
+## sora-cpp-sdk-2023.2.0
+
+- [UPDATE] Sora CPP SDK を 2023.2.0 にあげる
+    - @miosakuma
+
+## sora-cpp-sdk-2023.1.0
+
+- [UPDATE] Sora CPP SDK を 2023.1.0 にあげる
+    - @torikizi


### PR DESCRIPTION
CHANGES を追加しました。
CPP SDK Samples はリリース tag を作成しないので 同様である Unity SDK のサンプルにならって SDK のバージョンベースに記載しています。

CPP SDK 2023.1.0 から記載しています。