### PR TITLE
momo_sample に --hw-mjpeg-decoder を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@
   - SORA_CPP_SDK_VERSION を 2023.14.0 にあげる
   - WEBRTC_BUILD_VERSION を m117.5938.2.0 にあげる
   - @torikizi
+- [UPDATE]
+  - momo_sample に --hw-mjpeg-decoder オプションを追加する
+  - @enm10k
 
 ## sora-cpp-sdk-2023.１３.0
 

--- a/doc/USE_MOMO_SAMPLE.md
+++ b/doc/USE_MOMO_SAMPLE.md
@@ -191,6 +191,9 @@ $ ./momo_sample --signaling-url wss://sora.example.com/signaling --role sendrecv
 - `--resolution` : 映像配信する際の解像度
     - 解像度は `QVGA, VGA, HD, FHD, 4K, or [WIDTH]x[HEIGHT]` の値が指定可能です
     - 未指定の場合は `VGA` が設定されます
+- `--hw-mjpeg-decoder` : HW MJPEG デコーダーの利用 (true/false)
+    - 未指定の場合は false が設定されます
+    - NVIDIA Jetson のみで利用できます
 
 #### Sora に関するオプション
 

--- a/momo_sample/src/momo_sample.cpp
+++ b/momo_sample/src/momo_sample.cpp
@@ -299,10 +299,9 @@ int main(int argc, char* argv[]) {
                  "Video resolution (one of QVGA, VGA, HD, FHD, 4K, or "
                  "[WIDTH]x[HEIGHT])")
       ->check(is_valid_resolution);
-  app.add_option(
-      "--hw-mjpeg-decoder", config.hw_mjpeg_decoder,
-      "Perform MJPEG deoode and video resize by hardware acceleration "
-      "(only on supported devices)");
+  app.add_option("--hw-mjpeg-decoder", config.hw_mjpeg_decoder,
+                 "Perform MJPEG deoode and video resize by hardware "
+                 "acceleration only on supported devices (default: false)");
 
   // Sora に関するオプション
   app.add_option("--signaling-url", config.signaling_url, "Signaling URL")

--- a/momo_sample/src/momo_sample.cpp
+++ b/momo_sample/src/momo_sample.cpp
@@ -26,6 +26,7 @@ struct MomoSampleConfig {
   std::string video_codec_type;
   std::string audio_codec_type;
   std::string resolution = "VGA";
+  bool hw_mjpeg_decoder = false;
   int video_bit_rate = 0;
   int audio_bit_rate = 0;
   boost::json::value metadata;
@@ -45,7 +46,6 @@ struct MomoSampleConfig {
   int window_height = 480;
   bool show_me = false;
   bool fullscreen = false;
-  bool hw_mjpeg_decoder = false;
 
   struct Size {
     int width;
@@ -299,6 +299,10 @@ int main(int argc, char* argv[]) {
                  "Video resolution (one of QVGA, VGA, HD, FHD, 4K, or "
                  "[WIDTH]x[HEIGHT])")
       ->check(is_valid_resolution);
+  app.add_option(
+      "--hw-mjpeg-decoder", config.hw_mjpeg_decoder,
+      "Perform MJPEG deoode and video resize by hardware acceleration "
+      "(only on supported devices)");
 
   // Sora に関するオプション
   app.add_option("--signaling-url", config.signaling_url, "Signaling URL")
@@ -352,9 +356,6 @@ int main(int argc, char* argv[]) {
   app.add_flag("--fullscreen", config.fullscreen,
                "Use fullscreen window for videos");
   app.add_flag("--show-me", config.show_me, "Show self video");
-  app.add_flag("--hw-mjpeg-decoder", config.hw_mjpeg_decoder,
-               "Perform MJPEG deoode and video resize by hardware acceleration "
-               "(only on supported devices)");
 
   try {
     app.parse(argc, argv);

--- a/momo_sample/src/momo_sample.cpp
+++ b/momo_sample/src/momo_sample.cpp
@@ -45,6 +45,7 @@ struct MomoSampleConfig {
   int window_height = 480;
   bool show_me = false;
   bool fullscreen = false;
+  bool hw_mjpeg_decoder = false;
 
   struct Size {
     int width;
@@ -94,6 +95,7 @@ class MomoSample : public std::enable_shared_from_this<MomoSample>,
       cam_config.width = size.width;
       cam_config.height = size.height;
       cam_config.fps = 30;
+      cam_config.use_native = config_.hw_mjpeg_decoder;
       auto video_source = sora::CreateCameraDeviceCapturer(cam_config);
       if (video_source == nullptr) {
         RTC_LOG(LS_ERROR) << "Failed to create video source.";
@@ -350,6 +352,9 @@ int main(int argc, char* argv[]) {
   app.add_flag("--fullscreen", config.fullscreen,
                "Use fullscreen window for videos");
   app.add_flag("--show-me", config.show_me, "Show self video");
+  app.add_flag("--hw-mjpeg-decoder", config.hw_mjpeg_decoder,
+               "Perform MJPEG deoode and video resize by hardware acceleration "
+               "(only on supported devices)");
 
   try {
     app.parse(argc, argv);


### PR DESCRIPTION
## 変更内容

- テスト時に `cam_config.use_native` をコマンドラインから設定したいので、 momo にならって MomoArgs に `--hw-mjpeg-decoder` を追加しました