### PR TITLE
ローカルの CPP SDK を参照してビルドするためのオプションを追加する

### DIFF
--- a/base.py
+++ b/base.py
@@ -394,6 +394,78 @@ def get_webrtc_info(webrtcbuild: bool, source_dir: str, build_dir: str, install_
             libcxx_dir=os.path.join(install_dir, 'llvm', 'libcxx'),
         )
 
+class SoraInfo(NamedTuple):
+    # version_file: str
+    sora_install_dir: str
+    # sora_library_dir: str
+    boost_install_dir: str
+    # boost_library_dir: str
+    lyra_install_dir: str
+    # lyra_library_dir: str
+    # TODO: libwebrtc の情報もここで管理すべき?
+
+
+def install_sora_and_deps(source_dir, build_dir, install_dir):
+    version = read_version_file('VERSION')
+    # NOTE(enm10k): WebRTC も Sora CPP SDK と同じバージョンを使うのが良い気がする
+
+    # Boost
+    install_boost_args = {
+        'version': version['BOOST_VERSION'],
+        'version_file': os.path.join(install_dir, 'boost.version'),
+        'source_dir': source_dir,
+        'install_dir': install_dir,
+        'sora_version': version['SORA_CPP_SDK_VERSION'],
+        'platform': 'macos_arm64',
+    }
+    install_boost(**install_boost_args)
+
+    # Lyra
+    install_lyra_args = {
+        'version': version['LYRA_VERSION'],
+        'version_file': os.path.join(install_dir, 'lyra.version'),
+        'source_dir': source_dir,
+        'install_dir': install_dir,
+        'sora_version': version['SORA_CPP_SDK_VERSION'],
+        'platform': 'macos_arm64',
+    }
+    install_lyra(**install_lyra_args)
+
+    # CMake
+    install_cmake_args = {
+        'version': version['CMAKE_VERSION'],
+        'version_file': os.path.join(install_dir, 'cmake.version'),
+        'source_dir': source_dir,
+        'install_dir': install_dir,
+        'platform': 'macos-universal',
+        'ext': 'tar.gz'
+    }
+    install_cmake(**install_cmake_args)
+    add_path(os.path.join(install_dir, 'cmake', 'CMake.app', 'Contents', 'bin'))
+
+    # Sora C++ SDK
+    install_sora_args = {
+        'version': version['SORA_CPP_SDK_VERSION'],
+        'version_file': os.path.join(install_dir, 'sora.version'),
+        'source_dir': source_dir,
+        'install_dir': install_dir,
+        'platform': 'macos_arm64',
+    }
+    install_sora(**install_sora_args)
+
+def build_sora(sora_dir):
+    add_path(os.path.join(sora_install_dir, 'cmake', 'CMake.app', 'Contents', 'bin'))
+    # TODO: Sora CPP SDK をビルドする
+    pass
+
+# def get_sora_info(sora_dir: Optional[str] = None, sora_install_dir: Optional[str]):
+def get_sora_info(install_dir: Optional[str]):
+    return SoraInfo(
+        # version_file = os.path.join(sora_dir, 'VERSION')
+        sora_install_dir = os.path.join(install_dir, 'sora'),
+        boost_install_dir = os.path.join(install_dir, 'boost'),
+        lyra_install_dir = os.path.join(install_dir, 'lyra'),
+    )
 
 @versioned
 def install_llvm(version, install_dir,

--- a/base.py
+++ b/base.py
@@ -405,7 +405,7 @@ class SoraInfo(NamedTuple):
     # TODO: libwebrtc の情報もここで管理すべき?
 
 
-def install_sora_and_deps(source_dir, build_dir, install_dir):
+def install_sora_and_deps(platform: str, source_dir:str, build_dir:str, install_dir: str):
     version = read_version_file('VERSION')
     # NOTE(enm10k): WebRTC も Sora CPP SDK と同じバージョンを使うのが良い気がする
 
@@ -416,7 +416,7 @@ def install_sora_and_deps(source_dir, build_dir, install_dir):
         'source_dir': source_dir,
         'install_dir': install_dir,
         'sora_version': version['SORA_CPP_SDK_VERSION'],
-        'platform': 'macos_arm64',
+        'platform': platform,
     }
     install_boost(**install_boost_args)
 
@@ -427,21 +427,9 @@ def install_sora_and_deps(source_dir, build_dir, install_dir):
         'source_dir': source_dir,
         'install_dir': install_dir,
         'sora_version': version['SORA_CPP_SDK_VERSION'],
-        'platform': 'macos_arm64',
+        'platform': platform,
     }
     install_lyra(**install_lyra_args)
-
-    # CMake
-    install_cmake_args = {
-        'version': version['CMAKE_VERSION'],
-        'version_file': os.path.join(install_dir, 'cmake.version'),
-        'source_dir': source_dir,
-        'install_dir': install_dir,
-        'platform': 'macos-universal',
-        'ext': 'tar.gz'
-    }
-    install_cmake(**install_cmake_args)
-    add_path(os.path.join(install_dir, 'cmake', 'CMake.app', 'Contents', 'bin'))
 
     # Sora C++ SDK
     install_sora_args = {
@@ -449,7 +437,7 @@ def install_sora_and_deps(source_dir, build_dir, install_dir):
         'version_file': os.path.join(install_dir, 'sora.version'),
         'source_dir': source_dir,
         'install_dir': install_dir,
-        'platform': 'macos_arm64',
+        'platform': platform,
     }
     install_sora(**install_sora_args)
 

--- a/base.py
+++ b/base.py
@@ -439,8 +439,12 @@ def install_sora_and_deps(platform: str, source_dir:str, build_dir:str, install_
 
 
 def add_sora_arguments(parser):
-    parser.add_argument("--sora-dir", type=str, default=None)
-    parser.add_argument("--sora-args", type=shlex.split, default=[])
+    parser.add_argument("--sora-dir", type=str, default=None,
+                        help="Refer to local Sora C++ SDK. "
+                        "When this option is specified, Sora C++ SDK will also be built. "
+                        "Specifying an absolute path is recommended.")
+    parser.add_argument("--sora-args", type=shlex.split, default=[],
+                        help="Options for building local Sora C++ SDK when `--sora-dir` is specified.")
 
 
 def build_sora(platform: str, sora_dir: str, sora_args: List[str], debug: bool):

--- a/base.py
+++ b/base.py
@@ -451,8 +451,9 @@ def build_sora(platform: str, sora_dir: str, sora_args: List[str], debug: bool):
         cmd(['python3', 'run.py', platform, *sora_args])
 
 
-def get_sora_info(install_dir: str, sora_dir: Optional[str], platform: str, configuration: str) -> SoraInfo:
-    if sora_dir:
+def get_sora_info(install_dir: str, sora_dir: Optional[str], platform: str, debug: bool) -> SoraInfo:
+    if sora_dir is not None:
+        configuration = 'debug' if debug else 'release'
         install_dir = os.path.join(sora_dir, '_install', platform, configuration)
 
     return SoraInfo(

--- a/base.py
+++ b/base.py
@@ -438,7 +438,13 @@ def install_sora_and_deps(platform: str, source_dir:str, build_dir:str, install_
     install_sora(**install_sora_args)
 
 
-def build_sora(platform: str, sora_dir: str, debug: bool, args: List[str] = []):
+def add_sora_arguments(parser):
+    parser.add_argument("--sora-dir", type=str, default="")
+    parser.add_argument("--sora-args", type=str, default="")
+
+
+def build_sora(platform: str, sora_dir: str, sora_args: str, debug: bool):
+    args = sora_args.split()
     if debug and '--debug' not in args:
         args.insert(0, '--debug')
 

--- a/base.py
+++ b/base.py
@@ -399,7 +399,6 @@ class SoraInfo(NamedTuple):
     sora_install_dir: str
     boost_install_dir: str
     lyra_install_dir: str
-    # NOTE(enm10k): WebRTC も Sora CPP SDK と同じバージョンを使うのが良い気がする
 
 
 def install_sora_and_deps(platform: str, source_dir:str, build_dir:str, install_dir: str):

--- a/base.py
+++ b/base.py
@@ -438,7 +438,7 @@ def install_sora_and_deps(platform: str, source_dir:str, build_dir:str, install_
     install_sora(**install_sora_args)
 
 
-def build_sora(platform: str, sora_dir: str, args: Dict[str, str] = {}):
+def build_sora(platform: str, sora_dir: str, args: List[str] = []):
     with cd(sora_dir):
         cmd(['python3', 'run.py', platform, *args])
 

--- a/base.py
+++ b/base.py
@@ -438,7 +438,10 @@ def install_sora_and_deps(platform: str, source_dir:str, build_dir:str, install_
     install_sora(**install_sora_args)
 
 
-def build_sora(platform: str, sora_dir: str, args: List[str] = []):
+def build_sora(platform: str, sora_dir: str, debug: bool, args: List[str] = []):
+    if debug and '--debug' not in args:
+        args.insert(0, '--debug')
+
     with cd(sora_dir):
         cmd(['python3', 'run.py', platform, *args])
 

--- a/base.py
+++ b/base.py
@@ -438,17 +438,20 @@ def install_sora_and_deps(platform: str, source_dir:str, build_dir:str, install_
     install_sora(**install_sora_args)
 
 
+'''
+内部で os.path.abspath() を利用しており、 os.path.abspath() はカレントディレクトリに依存するため、
+この関数を利用する場合は ArgumentParser.parse_args() 実行前にカレントディレクトリを変更してはならない
+'''
 def add_sora_arguments(parser):
-    parser.add_argument("--sora-dir", type=str, default=None,
+    parser.add_argument("--sora-dir", type=os.path.abspath, default=None,
                         help="Refer to local Sora C++ SDK. "
-                        "When this option is specified, Sora C++ SDK will also be built. "
-                        "Specifying an absolute path is recommended.")
+                        "When this option is specified, Sora C++ SDK will also be built.")
     parser.add_argument("--sora-args", type=shlex.split, default=[],
                         help="Options for building local Sora C++ SDK when `--sora-dir` is specified.")
 
 
 def build_sora(platform: str, sora_dir: str, sora_args: List[str], debug: bool):
-    if debug and '--debug' not in args:
+    if debug and '--debug' not in sora_args:
         sora_args = ['--debug', *sora_args]
 
     with cd(sora_dir):

--- a/base.py
+++ b/base.py
@@ -438,10 +438,12 @@ def install_sora_and_deps(platform: str, source_dir:str, build_dir:str, install_
     install_sora(**install_sora_args)
 
 
-'''
-内部で os.path.abspath() を利用しており、 os.path.abspath() はカレントディレクトリに依存するため、
-この関数を利用する場合は ArgumentParser.parse_args() 実行前にカレントディレクトリを変更してはならない
-'''
+
+# 内部で os.path.abspath() を利用しており、 os.path.abspath() はカレントディレクトリに依存するため、
+# この関数を利用する場合は ArgumentParser.parse_args() 実行前にカレントディレクトリを変更してはならない
+# 
+# また、 --sora-args の指定には `--sora-args='--test'` のように `=` を使う必要がある
+# `--sora-args '--test'` のようにスペースを使うと、ハイフンから始まるオプションが正しく解釈されない
 def add_sora_arguments(parser):
     parser.add_argument("--sora-dir", type=os.path.abspath, default=None,
                         help="Refer to local Sora C++ SDK. "

--- a/base.py
+++ b/base.py
@@ -394,20 +394,16 @@ def get_webrtc_info(webrtcbuild: bool, source_dir: str, build_dir: str, install_
             libcxx_dir=os.path.join(install_dir, 'llvm', 'libcxx'),
         )
 
+
 class SoraInfo(NamedTuple):
-    # version_file: str
     sora_install_dir: str
-    # sora_library_dir: str
     boost_install_dir: str
-    # boost_library_dir: str
     lyra_install_dir: str
-    # lyra_library_dir: str
-    # TODO: libwebrtc の情報もここで管理すべき?
+    # NOTE(enm10k): WebRTC も Sora CPP SDK と同じバージョンを使うのが良い気がする
 
 
 def install_sora_and_deps(platform: str, source_dir:str, build_dir:str, install_dir: str):
     version = read_version_file('VERSION')
-    # NOTE(enm10k): WebRTC も Sora CPP SDK と同じバージョンを使うのが良い気がする
 
     # Boost
     install_boost_args = {
@@ -441,19 +437,19 @@ def install_sora_and_deps(platform: str, source_dir:str, build_dir:str, install_
     }
     install_sora(**install_sora_args)
 
-def build_sora(sora_dir):
-    add_path(os.path.join(sora_install_dir, 'cmake', 'CMake.app', 'Contents', 'bin'))
-    # TODO: Sora CPP SDK をビルドする
-    pass
 
-# def get_sora_info(sora_dir: Optional[str] = None, sora_install_dir: Optional[str]):
-def get_sora_info(install_dir: Optional[str]):
+def build_sora(platform: str, sora_dir: str, args: Dict[str, str] = {}):
+    with cd(sora_dir):
+        cmd(['python3', 'run.py', platform, *args])
+
+
+def get_sora_info(install_dir: str):
     return SoraInfo(
-        # version_file = os.path.join(sora_dir, 'VERSION')
         sora_install_dir = os.path.join(install_dir, 'sora'),
         boost_install_dir = os.path.join(install_dir, 'boost'),
         lyra_install_dir = os.path.join(install_dir, 'lyra'),
     )
+
 
 @versioned
 def install_llvm(version, install_dir,

--- a/base.py
+++ b/base.py
@@ -4,6 +4,7 @@ import os
 import urllib.parse
 import zipfile
 import tarfile
+import shlex
 import shutil
 import platform
 import multiprocessing
@@ -438,20 +439,22 @@ def install_sora_and_deps(platform: str, source_dir:str, build_dir:str, install_
 
 
 def add_sora_arguments(parser):
-    parser.add_argument("--sora-dir", type=str, default="")
-    parser.add_argument("--sora-args", type=str, default="")
+    parser.add_argument("--sora-dir", type=str, default=None)
+    parser.add_argument("--sora-args", type=shlex.split, default=[])
 
 
-def build_sora(platform: str, sora_dir: str, sora_args: str, debug: bool):
-    args = sora_args.split()
+def build_sora(platform: str, sora_dir: str, sora_args: List[str], debug: bool):
     if debug and '--debug' not in args:
-        args.insert(0, '--debug')
+        sora_args = ['--debug', *sora_args]
 
     with cd(sora_dir):
-        cmd(['python3', 'run.py', platform, *args])
+        cmd(['python3', 'run.py', platform, *sora_args])
 
 
-def get_sora_info(install_dir: str):
+def get_sora_info(install_dir: str, sora_dir: Optional[str], platform: str, configuration: str) -> SoraInfo:
+    if sora_dir:
+        install_dir = os.path.join(sora_dir, '_install', platform, configuration)
+
     return SoraInfo(
         sora_install_dir = os.path.join(install_dir, 'sora'),
         boost_install_dir = os.path.join(install_dir, 'boost'),

--- a/messaging_recvonly_sample/macos_arm64/run.py
+++ b/messaging_recvonly_sample/macos_arm64/run.py
@@ -2,6 +2,7 @@ import os
 import multiprocessing
 import argparse
 import sys
+from typing import Optional, List
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
 sys.path.insert(0, BASE_DIR)
@@ -15,17 +16,18 @@ from base import (  # noqa
     add_path,
     cmake_path,
     read_version_file,
+    get_sora_info,
     get_webrtc_info,
     install_webrtc,
-    install_boost,
-    install_lyra,
+    build_sora,
+    install_sora_and_deps,
     install_cmake,
-    install_sora,
     install_cli11,
+    add_sora_arguments,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[str], sora_args: List[str]):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -39,27 +41,11 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_webrtc(**install_webrtc_args)
 
-        # Boost
-        install_boost_args = {
-            'version': version['BOOST_VERSION'],
-            'version_file': os.path.join(install_dir, 'boost.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'macos_arm64',
-        }
-        install_boost(**install_boost_args)
-
-        # Lyra
-        install_lyra_args = {
-            'version': version['LYRA_VERSION'],
-            'version_file': os.path.join(install_dir, 'lyra.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'macos_arm64',
-        }
-        install_lyra(**install_lyra_args)
+        # Sora C++ SDK, Boost, Lyra
+        if sora_dir is None:
+            install_sora_and_deps('macos_arm64', source_dir, build_dir, install_dir)
+        else:
+            build_sora('macos_arm64', sora_dir, sora_args, debug)
 
         # CMake
         install_cmake_args = {
@@ -73,16 +59,6 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         install_cmake(**install_cmake_args)
         add_path(os.path.join(install_dir, 'cmake', 'CMake.app', 'Contents', 'bin'))
 
-        # Sora C++ SDK
-        install_sora_args = {
-            'version': version['SORA_CPP_SDK_VERSION'],
-            'version_file': os.path.join(install_dir, 'sora.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'platform': 'macos_arm64',
-        }
-        install_sora(**install_sora_args)
-
         # CLI11
         install_cli11_args = {
             'version': version['CLI11_VERSION'],
@@ -95,6 +71,7 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
+    add_sora_arguments(parser)
 
     args = parser.parse_args()
 
@@ -107,7 +84,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir, args.sora_args)
 
     configuration = 'Debug' if args.debug else 'Release'
 
@@ -115,14 +92,15 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, args.debug)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
-        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
-        cmake_args.append(f"-DLYRA_DIR={cmake_path(os.path.join(install_dir, 'lyra'))}")
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
+        cmake_args.append(f"-DLYRA_DIR={cmake_path(sora_info.lyra_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
-        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(sora_info.sora_install_dir)}")
         cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
 
         # クロスコンパイルの設定。

--- a/messaging_recvonly_sample/ubuntu-20.04_armv8_jetson/run.py
+++ b/messaging_recvonly_sample/ubuntu-20.04_armv8_jetson/run.py
@@ -3,6 +3,7 @@ import multiprocessing
 import argparse
 import sys
 import hashlib
+from typing import Optional, List
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
 sys.path.insert(0, BASE_DIR)
@@ -15,19 +16,20 @@ from base import (  # noqa
     add_path,
     cmake_path,
     read_version_file,
+    get_sora_info,
     get_webrtc_info,
     install_rootfs,
     install_webrtc,
     install_llvm,
-    install_boost,
-    install_lyra,
+    build_sora,
+    install_sora_and_deps,
     install_cmake,
-    install_sora,
     install_cli11,
+    add_sora_arguments,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[str], sora_args: List[str]):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -79,27 +81,11 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_llvm(**install_llvm_args)
 
-        # Boost
-        install_boost_args = {
-            'version': version['BOOST_VERSION'],
-            'version_file': os.path.join(install_dir, 'boost.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-20.04_armv8_jetson',
-        }
-        install_boost(**install_boost_args)
-
-        # Lyra
-        install_lyra_args = {
-            'version': version['LYRA_VERSION'],
-            'version_file': os.path.join(install_dir, 'lyra.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-20.04_armv8_jetson',
-        }
-        install_lyra(**install_lyra_args)
+        # Sora C++ SDK, Boost, Lyra
+        if sora_dir is None:
+            install_sora_and_deps('ubuntu-20.04_armv8_jetson', source_dir, build_dir, install_dir)
+        else:
+            build_sora('ubuntu-20.04_armv8_jetson', sora_dir, sora_args, debug)
 
         # CMake
         install_cmake_args = {
@@ -113,16 +99,6 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         install_cmake(**install_cmake_args)
         add_path(os.path.join(install_dir, 'cmake', 'bin'))
 
-        # Sora C++ SDK
-        install_sora_args = {
-            'version': version['SORA_CPP_SDK_VERSION'],
-            'version_file': os.path.join(install_dir, 'sora.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'platform': 'ubuntu-20.04_armv8_jetson',
-        }
-        install_sora(**install_sora_args)
-
         # CLI11
         install_cli11_args = {
             'version': version['CLI11_VERSION'],
@@ -135,6 +111,7 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
+    add_sora_arguments(parser)
 
     args = parser.parse_args()
 
@@ -147,7 +124,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir, args.sora_args)
 
     configuration = 'Debug' if args.debug else 'Release'
 
@@ -155,14 +132,15 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, args.debug)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
-        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
-        cmake_args.append(f"-DLYRA_DIR={cmake_path(os.path.join(install_dir, 'lyra'))}")
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
+        cmake_args.append(f"-DLYRA_DIR={cmake_path(sora_info.lyra_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
-        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(sora_info.sora_install_dir)}")
         cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
 
         # クロスコンパイルの設定。

--- a/messaging_recvonly_sample/ubuntu-20.04_x86_64/run.py
+++ b/messaging_recvonly_sample/ubuntu-20.04_x86_64/run.py
@@ -2,6 +2,7 @@ import os
 import multiprocessing
 import argparse
 import sys
+from typing import Optional, List
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
 sys.path.insert(0, BASE_DIR)
@@ -14,18 +15,20 @@ from base import (  # noqa
     add_path,
     cmake_path,
     read_version_file,
+    get_sora_info,
     get_webrtc_info,
     install_webrtc,
     install_llvm,
-    install_boost,
-    install_lyra,
+    build_sora,
+    install_sora_and_deps,
     install_cmake,
     install_sora,
     install_cli11,
+    add_sora_arguments,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[str], sora_args: List[str]):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -65,27 +68,10 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_llvm(**install_llvm_args)
 
-        # Boost
-        install_boost_args = {
-            'version': version['BOOST_VERSION'],
-            'version_file': os.path.join(install_dir, 'boost.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-20.04_x86_64',
-        }
-        install_boost(**install_boost_args)
-
-        # Lyra
-        install_lyra_args = {
-            'version': version['LYRA_VERSION'],
-            'version_file': os.path.join(install_dir, 'lyra.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-20.04_x86_64',
-        }
-        install_lyra(**install_lyra_args)
+        if sora_dir is None:
+            install_sora_and_deps('ubuntu-20.04_x86_64', source_dir, build_dir, install_dir)
+        else:
+            build_sora('ubuntu-20.04_x86_64', sora_dir, sora_args, debug)
 
         # CMake
         install_cmake_args = {
@@ -99,16 +85,6 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         install_cmake(**install_cmake_args)
         add_path(os.path.join(install_dir, 'cmake', 'bin'))
 
-        # Sora C++ SDK
-        install_sora_args = {
-            'version': version['SORA_CPP_SDK_VERSION'],
-            'version_file': os.path.join(install_dir, 'sora.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'platform': 'ubuntu-20.04_x86_64',
-        }
-        install_sora(**install_sora_args)
-
         # CLI11
         install_cli11_args = {
             'version': version['CLI11_VERSION'],
@@ -121,6 +97,7 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
+    add_sora_arguments(parser)
 
     args = parser.parse_args()
 
@@ -133,7 +110,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir, args.sora_args)
 
     configuration = 'Debug' if args.debug else 'Release'
 
@@ -141,14 +118,15 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, args.debug)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
-        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
-        cmake_args.append(f"-DLYRA_DIR={cmake_path(os.path.join(install_dir, 'lyra'))}")
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
+        cmake_args.append(f"-DLYRA_DIR={cmake_path(sora_info.lyra_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
-        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(sora_info.sora_install_dir)}")
         cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
 
         # クロスコンパイルの設定。

--- a/messaging_recvonly_sample/ubuntu-22.04_x86_64/run.py
+++ b/messaging_recvonly_sample/ubuntu-22.04_x86_64/run.py
@@ -2,6 +2,7 @@ import os
 import multiprocessing
 import argparse
 import sys
+from typing import Optional, List
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
 sys.path.insert(0, BASE_DIR)
@@ -14,18 +15,19 @@ from base import (  # noqa
     add_path,
     cmake_path,
     read_version_file,
+    get_sora_info,
     get_webrtc_info,
     install_webrtc,
     install_llvm,
-    install_boost,
-    install_lyra,
+    build_sora,
+    install_sora_and_deps,
     install_cmake,
-    install_sora,
     install_cli11,
+    add_sora_arguments,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[str], sora_args: List[str]):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -65,27 +67,11 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_llvm(**install_llvm_args)
 
-        # Boost
-        install_boost_args = {
-            'version': version['BOOST_VERSION'],
-            'version_file': os.path.join(install_dir, 'boost.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-22.04_x86_64',
-        }
-        install_boost(**install_boost_args)
-
-        # Lyra
-        install_lyra_args = {
-            'version': version['LYRA_VERSION'],
-            'version_file': os.path.join(install_dir, 'lyra.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-22.04_x86_64',
-        }
-        install_lyra(**install_lyra_args)
+       # Sora C++ SDK, Boost, Lyra
+        if sora_dir is None:
+            install_sora_and_deps('ubuntu-22.04_x86_64', source_dir, build_dir, install_dir)
+        else:
+            build_sora('ubuntu-22.04_x86_64', sora_dir, sora_args, debug)
 
         # CMake
         install_cmake_args = {
@@ -99,16 +85,6 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         install_cmake(**install_cmake_args)
         add_path(os.path.join(install_dir, 'cmake', 'bin'))
 
-        # Sora C++ SDK
-        install_sora_args = {
-            'version': version['SORA_CPP_SDK_VERSION'],
-            'version_file': os.path.join(install_dir, 'sora.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'platform': 'ubuntu-22.04_x86_64',
-        }
-        install_sora(**install_sora_args)
-
         # CLI11
         install_cli11_args = {
             'version': version['CLI11_VERSION'],
@@ -121,6 +97,7 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
+    add_sora_arguments(parser)
 
     args = parser.parse_args()
 
@@ -133,7 +110,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir, args.sora_args)
 
     configuration = 'Debug' if args.debug else 'Release'
 
@@ -141,14 +118,15 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, args.debug)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
-        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
-        cmake_args.append(f"-DLYRA_DIR={cmake_path(os.path.join(install_dir, 'lyra'))}")
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
+        cmake_args.append(f"-DLYRA_DIR={cmake_path(sora_info.lyra_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
-        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(sora_info.sora_install_dir)}")
         cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
 
         # クロスコンパイルの設定。

--- a/messaging_recvonly_sample/windows_x86_64/run.py
+++ b/messaging_recvonly_sample/windows_x86_64/run.py
@@ -2,6 +2,7 @@ import os
 import multiprocessing
 import argparse
 import sys
+from typing import Optional, List
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
 sys.path.insert(0, BASE_DIR)
@@ -14,17 +15,18 @@ from base import (  # noqa
     add_path,
     cmake_path,
     read_version_file,
+    get_sora_info,
     get_webrtc_info,
     install_webrtc,
-    install_boost,
-    install_lyra,
+    build_sora,
+    install_sora_and_deps,
     install_cmake,
-    install_sora,
     install_cli11,
+    add_sora_arguments,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[str], sora_args: List[str]):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -39,27 +41,11 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 
         install_webrtc(**install_webrtc_args)
 
-        # Boost
-        install_boost_args = {
-            'version': version['BOOST_VERSION'],
-            'version_file': os.path.join(install_dir, 'boost.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'windows_x86_64',
-        }
-        install_boost(**install_boost_args)
-
-        # Lyra
-        install_lyra_args = {
-            'version': version['LYRA_VERSION'],
-            'version_file': os.path.join(install_dir, 'lyra.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'windows_x86_64',
-        }
-        install_lyra(**install_lyra_args)
+        # Sora C++ SDK, Boost, Lyra
+        if sora_dir is None:
+            install_sora_and_deps('windows_x86_64', source_dir, build_dir, install_dir)
+        else:
+            build_sora('windows_x86_64', sora_dir, sora_args, debug)
 
         # CMake
         install_cmake_args = {
@@ -74,16 +60,6 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 
         add_path(os.path.join(install_dir, 'cmake', 'bin'))
 
-        # Sora C++ SDK
-        install_sora_args = {
-            'version': version['SORA_CPP_SDK_VERSION'],
-            'version_file': os.path.join(install_dir, 'sora.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'platform': 'windows_x86_64',
-        }
-        install_sora(**install_sora_args)
-
         # CLI11
         install_cli11_args = {
             'version': version['CLI11_VERSION'],
@@ -96,6 +72,7 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
+    add_sora_arguments(parser)
 
     args = parser.parse_args()
 
@@ -108,7 +85,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir, args.sora_args)
 
     configuration = 'Debug' if args.debug else 'Release'
 
@@ -116,14 +93,15 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, args.debug)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
-        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
-        cmake_args.append(f"-DLYRA_DIR={cmake_path(os.path.join(install_dir, 'lyra'))}")
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
+        cmake_args.append(f"-DLYRA_DIR={cmake_path(sora_info.lyra_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
-        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(sora_info.sora_install_dir)}")
         cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
         cmd(['cmake', os.path.join(PROJECT_DIR)] + cmake_args)
         cmd(['cmake', '--build', '.', f'-j{multiprocessing.cpu_count()}', '--config', configuration])

--- a/sdl_sample/ubuntu-20.04_armv8_jetson/run.py
+++ b/sdl_sample/ubuntu-20.04_armv8_jetson/run.py
@@ -3,6 +3,7 @@ import multiprocessing
 import argparse
 import sys
 import hashlib
+from typing import Optional, List
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
 sys.path.insert(0, BASE_DIR)
@@ -14,21 +15,22 @@ from base import (  # noqa
     mkdir_p,
     add_path,
     cmake_path,
+    get_sora_info,
     read_version_file,
     get_webrtc_info,
     install_rootfs,
     install_webrtc,
     install_llvm,
-    install_boost,
-    install_lyra,
+    build_sora,
+    install_sora_and_deps,
     install_cmake,
     install_sdl2,
-    install_sora,
     install_cli11,
+    add_sora_arguments,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[str], sora_args: List[str]):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -81,27 +83,11 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_llvm(**install_llvm_args)
 
-        # Boost
-        install_boost_args = {
-            'version': version['BOOST_VERSION'],
-            'version_file': os.path.join(install_dir, 'boost.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-20.04_armv8_jetson',
-        }
-        install_boost(**install_boost_args)
-
-        # Lyra
-        install_lyra_args = {
-            'version': version['LYRA_VERSION'],
-            'version_file': os.path.join(install_dir, 'lyra.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-20.04_armv8_jetson',
-        }
-        install_lyra(**install_lyra_args)
+        # Sora C++ SDK, Boost, Lyra
+        if sora_dir is None:
+            install_sora_and_deps('ubuntu-20.04_armv8_jetson', source_dir, build_dir, install_dir)
+        else:
+            build_sora('ubuntu-20.04_armv8_jetson', sora_dir, sora_args, debug)
 
         # CMake
         install_cmake_args = {
@@ -141,16 +127,6 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_sdl2(**install_sdl2_args)
 
-        # Sora C++ SDK
-        install_sora_args = {
-            'version': version['SORA_CPP_SDK_VERSION'],
-            'version_file': os.path.join(install_dir, 'sora.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'platform': 'ubuntu-20.04_armv8_jetson',
-        }
-        install_sora(**install_sora_args)
-
         # CLI11
         install_cli11_args = {
             'version': version['CLI11_VERSION'],
@@ -163,6 +139,7 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
+    add_sora_arguments(parser)
 
     args = parser.parse_args()
 
@@ -175,7 +152,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir, args.sora_args)
 
     configuration = 'Debug' if args.debug else 'Release'
 
@@ -183,14 +160,15 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, args.debug)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
-        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
-        cmake_args.append(f"-DLYRA_DIR={cmake_path(os.path.join(install_dir, 'lyra'))}")
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
+        cmake_args.append(f"-DLYRA_DIR={cmake_path(sora_info.lyra_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
-        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(sora_info.sora_install_dir)}")
         cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
         cmake_args.append(f"-DSDL2_DIR={cmake_path(os.path.join(install_dir, 'sdl2'))}")
 

--- a/sdl_sample/ubuntu-20.04_x86_64/run.py
+++ b/sdl_sample/ubuntu-20.04_x86_64/run.py
@@ -2,6 +2,7 @@ import os
 import multiprocessing
 import argparse
 import sys
+from typing import Optional, List
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
 sys.path.insert(0, BASE_DIR)
@@ -13,20 +14,21 @@ from base import (  # noqa
     mkdir_p,
     add_path,
     cmake_path,
+    get_sora_info,
     read_version_file,
     get_webrtc_info,
     install_webrtc,
     install_llvm,
-    install_boost,
-    install_lyra,
+    build_sora,
+    install_sora_and_deps,
     install_cmake,
     install_sdl2,
-    install_sora,
     install_cli11,
+    add_sora_arguments,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[str], sora_args: List[str]):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -66,27 +68,11 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_llvm(**install_llvm_args)
 
-        # Boost
-        install_boost_args = {
-            'version': version['BOOST_VERSION'],
-            'version_file': os.path.join(install_dir, 'boost.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-20.04_x86_64',
-        }
-        install_boost(**install_boost_args)
-
-        # Lyra
-        install_lyra_args = {
-            'version': version['LYRA_VERSION'],
-            'version_file': os.path.join(install_dir, 'lyra.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-20.04_x86_64',
-        }
-        install_lyra(**install_lyra_args)
+        # Sora C++ SDK, Boost, Lyra
+        if sora_dir is None:
+            install_sora_and_deps('ubuntu-20.04_x86_64', source_dir, build_dir, install_dir)
+        else:
+            build_sora('ubuntu-20.04_x86_64', sora_dir, sora_args, debug)
 
         # CMake
         install_cmake_args = {
@@ -116,16 +102,6 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_sdl2(**install_sdl2_args)
 
-        # Sora C++ SDK
-        install_sora_args = {
-            'version': version['SORA_CPP_SDK_VERSION'],
-            'version_file': os.path.join(install_dir, 'sora.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'platform': 'ubuntu-20.04_x86_64',
-        }
-        install_sora(**install_sora_args)
-
         # CLI11
         install_cli11_args = {
             'version': version['CLI11_VERSION'],
@@ -138,6 +114,7 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
+    add_sora_arguments(parser)
 
     args = parser.parse_args()
 
@@ -150,7 +127,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir, args.sora_args)
 
     configuration = 'Debug' if args.debug else 'Release'
 
@@ -158,14 +135,15 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, args.debug)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
-        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
-        cmake_args.append(f"-DLYRA_DIR={cmake_path(os.path.join(install_dir, 'lyra'))}")
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
+        cmake_args.append(f"-DLYRA_DIR={cmake_path(sora_info.lyra_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
-        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(sora_info.sora_install_dir)}")
         cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
         cmake_args.append(f"-DSDL2_DIR={cmake_path(os.path.join(install_dir, 'sdl2'))}")
 

--- a/sdl_sample/ubuntu-22.04_x86_64/run.py
+++ b/sdl_sample/ubuntu-22.04_x86_64/run.py
@@ -2,6 +2,7 @@ import os
 import multiprocessing
 import argparse
 import sys
+from typing import Optional, List
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
 sys.path.insert(0, BASE_DIR)
@@ -14,19 +15,20 @@ from base import (  # noqa
     add_path,
     cmake_path,
     read_version_file,
+    get_sora_info,
     get_webrtc_info,
     install_webrtc,
     install_llvm,
-    install_boost,
-    install_lyra,
+    build_sora,
+    install_sora_and_deps,
     install_cmake,
     install_sdl2,
-    install_sora,
     install_cli11,
+    add_sora_arguments,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[str], sora_args: List[str]):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -66,27 +68,11 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_llvm(**install_llvm_args)
 
-        # Boost
-        install_boost_args = {
-            'version': version['BOOST_VERSION'],
-            'version_file': os.path.join(install_dir, 'boost.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-22.04_x86_64',
-        }
-        install_boost(**install_boost_args)
-
-        # Lyra
-        install_lyra_args = {
-            'version': version['LYRA_VERSION'],
-            'version_file': os.path.join(install_dir, 'lyra.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-22.04_x86_64',
-        }
-        install_lyra(**install_lyra_args)
+        # Sora C++ SDK, Boost, Lyra
+        if sora_dir is None:
+            install_sora_and_deps('ubuntu-22.04_x86_64', source_dir, build_dir, install_dir)
+        else:
+            build_sora('ubuntu-22.04_x86_64', sora_dir, sora_args, debug)
 
         # CMake
         install_cmake_args = {
@@ -116,16 +102,6 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_sdl2(**install_sdl2_args)
 
-        # Sora C++ SDK
-        install_sora_args = {
-            'version': version['SORA_CPP_SDK_VERSION'],
-            'version_file': os.path.join(install_dir, 'sora.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'platform': 'ubuntu-22.04_x86_64',
-        }
-        install_sora(**install_sora_args)
-
         # CLI11
         install_cli11_args = {
             'version': version['CLI11_VERSION'],
@@ -138,6 +114,7 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
+    add_sora_arguments(parser)
 
     args = parser.parse_args()
 
@@ -150,7 +127,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir, args.sora_args)
 
     configuration = 'Debug' if args.debug else 'Release'
 
@@ -158,14 +135,15 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, args.debug)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
-        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
-        cmake_args.append(f"-DLYRA_DIR={cmake_path(os.path.join(install_dir, 'lyra'))}")
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
+        cmake_args.append(f"-DLYRA_DIR={cmake_path(sora_info.lyra_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
-        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(sora_info.sora_install_dir)}")
         cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
         cmake_args.append(f"-DSDL2_DIR={cmake_path(os.path.join(install_dir, 'sdl2'))}")
 

--- a/sdl_sample/windows_x86_64/run.py
+++ b/sdl_sample/windows_x86_64/run.py
@@ -2,6 +2,7 @@ import os
 import multiprocessing
 import argparse
 import sys
+from typing import Optional, List
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
 sys.path.insert(0, BASE_DIR)
@@ -14,18 +15,19 @@ from base import (  # noqa
     add_path,
     cmake_path,
     read_version_file,
+    get_sora_info,
     get_webrtc_info,
     install_webrtc,
-    install_boost,
-    install_lyra,
+    build_sora,
+    install_sora_and_deps,
     install_cmake,
     install_sdl2,
-    install_sora,
     install_cli11,
+    add_sora_arguments,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[str], sora_args: List[str]):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -40,27 +42,11 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 
         install_webrtc(**install_webrtc_args)
 
-        # Boost
-        install_boost_args = {
-            'version': version['BOOST_VERSION'],
-            'version_file': os.path.join(install_dir, 'boost.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'windows_x86_64',
-        }
-        install_boost(**install_boost_args)
-
-        # Lyra
-        install_lyra_args = {
-            'version': version['LYRA_VERSION'],
-            'version_file': os.path.join(install_dir, 'lyra.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'windows_x86_64',
-        }
-        install_lyra(**install_lyra_args)
+        # Sora C++ SDK, Boost, Lyra
+        if sora_dir is None:
+            install_sora_and_deps('windows_x86_64', source_dir, build_dir, install_dir)
+        else:
+            build_sora('windows_x86_64', sora_dir, sora_args, debug)
 
         # CMake
         install_cmake_args = {
@@ -88,16 +74,6 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_sdl2(**install_sdl2_args)
 
-        # Sora C++ SDK
-        install_sora_args = {
-            'version': version['SORA_CPP_SDK_VERSION'],
-            'version_file': os.path.join(install_dir, 'sora.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'platform': 'windows_x86_64',
-        }
-        install_sora(**install_sora_args)
-
         # CLI11
         install_cli11_args = {
             'version': version['CLI11_VERSION'],
@@ -110,6 +86,7 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
+    add_sora_arguments(parser)
 
     args = parser.parse_args()
 
@@ -122,7 +99,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir, args.sora_args)
 
     configuration = 'Debug' if args.debug else 'Release'
 
@@ -130,14 +107,15 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, args.debug)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
-        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
-        cmake_args.append(f"-DLYRA_DIR={cmake_path(os.path.join(install_dir, 'lyra'))}")
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
+        cmake_args.append(f"-DLYRA_DIR={cmake_path(sora_info.lyra_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
-        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(sora_info.sora_install_dir)}")
         cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
         cmake_args.append(f"-DSDL2_DIR={cmake_path(os.path.join(install_dir, 'sdl2'))}")
         cmd(['cmake', os.path.join(PROJECT_DIR)] + cmake_args)

--- a/sumomo/macos_arm64/run.py
+++ b/sumomo/macos_arm64/run.py
@@ -26,10 +26,11 @@ from base import (  # noqa
     install_cmake,
     install_sdl2,
     install_cli11,
+    add_sora_arguments,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str, sora_args: str):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -47,7 +48,7 @@ def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str):
 
         # Sora C++ SDK, Boost, Lyra
         if sora_dir:
-            build_sora('macos_arm64', sora_dir, debug)
+            build_sora('macos_arm64', sora_dir, sora_args, debug)
         else:
             install_sora_and_deps('macos_arm64', source_dir, build_dir, install_dir)
 
@@ -96,7 +97,7 @@ def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
-    parser.add_argument("--sora-dir", default="")
+    add_sora_arguments(parser)
 
     args = parser.parse_args()
 
@@ -109,7 +110,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir, args.sora_args)
 
     configuration = 'Debug' if args.debug else 'Release'
 

--- a/sumomo/macos_arm64/run.py
+++ b/sumomo/macos_arm64/run.py
@@ -29,7 +29,7 @@ from base import (  # noqa
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug, local_sora: str):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -46,8 +46,8 @@ def install_deps(source_dir, build_dir, install_dir, debug, local_sora: str):
         sysroot = cmdcap(['xcrun', '--sdk', 'macosx', '--show-sdk-path'])
 
         # Sora C++ SDK, Boost, Lyra
-        if local_sora:
-            build_sora()
+        if sora_dir:
+            build_sora('macos_arm64', sora_dir)
         else:
             install_sora_and_deps('macos_arm64', source_dir, build_dir, install_dir)
 
@@ -96,7 +96,7 @@ def install_deps(source_dir, build_dir, install_dir, debug, local_sora: str):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
-    parser.add_argument("--local-sora", default="")
+    parser.add_argument("--sora-dir", default="")
 
     args = parser.parse_args()
 
@@ -109,7 +109,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug, args.local_sora)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir)
 
     configuration = 'Debug' if args.debug else 'Release'
 
@@ -118,8 +118,8 @@ def main():
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
 
-        if args.local_sora:
-            sora_info = get_sora_info(os.path.join(args.local_sora, '_install', dir, configuration_dir))
+        if args.sora_dir:
+            sora_info = get_sora_info(os.path.join(args.sora_dir, '_install', dir, configuration_dir))
         else:
             sora_info = get_sora_info(install_dir)
 

--- a/sumomo/macos_arm64/run.py
+++ b/sumomo/macos_arm64/run.py
@@ -47,7 +47,7 @@ def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str):
 
         # Sora C++ SDK, Boost, Lyra
         if sora_dir:
-            build_sora('macos_arm64', sora_dir)
+            build_sora('macos_arm64', sora_dir, debug)
         else:
             install_sora_and_deps('macos_arm64', source_dir, build_dir, install_dir)
 

--- a/sumomo/macos_arm64/run.py
+++ b/sumomo/macos_arm64/run.py
@@ -2,9 +2,6 @@ import os
 import multiprocessing
 import argparse
 import sys
-
-from typing import Optional
-
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
 sys.path.insert(0, BASE_DIR)

--- a/sumomo/macos_arm64/run.py
+++ b/sumomo/macos_arm64/run.py
@@ -14,15 +14,17 @@ from base import (  # noqa
     cd,
     cmd,
     cmdcap,
+    add_path,
     cmake_path,
     get_sora_info,
     mkdir_p,
     read_version_file,
     get_webrtc_info,
     install_webrtc,
+    build_sora,
+    install_sora_and_deps,
     install_cmake,
     install_sdl2,
-    install_sora_and_deps,
     install_cli11,
 )
 
@@ -43,11 +45,23 @@ def install_deps(source_dir, build_dir, install_dir, debug, local_sora: str):
 
         sysroot = cmdcap(['xcrun', '--sdk', 'macosx', '--show-sdk-path'])
 
-        # Sora, Boost, Lyra, CMake
+        # Sora C++ SDK, Boost, Lyra
         if local_sora:
             build_sora()
         else:
-            install_sora_and_deps(source_dir, build_dir, install_dir)
+            install_sora_and_deps('macos_arm64', source_dir, build_dir, install_dir)
+
+        # CMake
+        install_cmake_args = {
+            'version': version['CMAKE_VERSION'],
+            'version_file': os.path.join(install_dir, 'cmake.version'),
+            'source_dir': source_dir,
+            'install_dir': install_dir,
+            'platform': 'macos-universal',
+            'ext': 'tar.gz'
+        }
+        install_cmake(**install_cmake_args)
+        add_path(os.path.join(install_dir, 'cmake', 'CMake.app', 'Contents', 'bin'))
 
         # SDL2
         install_sdl2_args = {
@@ -105,7 +119,7 @@ def main():
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
 
         if args.local_sora:
-            sora_info = os.path.join(args.local_sora, '_install', dir, configuration_dir)
+            sora_info = get_sora_info(os.path.join(args.local_sora, '_install', dir, configuration_dir))
         else:
             sora_info = get_sora_info(install_dir)
 

--- a/sumomo/macos_arm64/run.py
+++ b/sumomo/macos_arm64/run.py
@@ -45,10 +45,10 @@ def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[s
         sysroot = cmdcap(['xcrun', '--sdk', 'macosx', '--show-sdk-path'])
 
         # Sora C++ SDK, Boost, Lyra
-        if sora_dir:
-            build_sora('macos_arm64', sora_dir, sora_args, debug)
-        else:
+        if sora_dir is None:
             install_sora_and_deps('macos_arm64', source_dir, build_dir, install_dir)
+        else:
+            build_sora('macos_arm64', sora_dir, sora_args, debug)
 
         # CMake
         install_cmake_args = {
@@ -116,7 +116,7 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
-        sora_info = get_sora_info(install_dir, args.sora_dir, dir, configuration_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, args.debug)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')

--- a/sumomo/macos_arm64/run.py
+++ b/sumomo/macos_arm64/run.py
@@ -2,6 +2,9 @@ import os
 import multiprocessing
 import argparse
 import sys
+
+from typing import Optional
+
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
 sys.path.insert(0, BASE_DIR)
@@ -11,22 +14,20 @@ from base import (  # noqa
     cd,
     cmd,
     cmdcap,
-    mkdir_p,
-    add_path,
     cmake_path,
+    get_sora_info,
+    mkdir_p,
     read_version_file,
     get_webrtc_info,
     install_webrtc,
-    install_boost,
-    install_lyra,
     install_cmake,
     install_sdl2,
-    install_sora,
+    install_sora_and_deps,
     install_cli11,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug):
+def install_deps(source_dir, build_dir, install_dir, debug, local_sora: str):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -42,39 +43,11 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 
         sysroot = cmdcap(['xcrun', '--sdk', 'macosx', '--show-sdk-path'])
 
-        # Boost
-        install_boost_args = {
-            'version': version['BOOST_VERSION'],
-            'version_file': os.path.join(install_dir, 'boost.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'macos_arm64',
-        }
-        install_boost(**install_boost_args)
-
-        # Lyra
-        install_lyra_args = {
-            'version': version['LYRA_VERSION'],
-            'version_file': os.path.join(install_dir, 'lyra.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'macos_arm64',
-        }
-        install_lyra(**install_lyra_args)
-
-        # CMake
-        install_cmake_args = {
-            'version': version['CMAKE_VERSION'],
-            'version_file': os.path.join(install_dir, 'cmake.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'platform': 'macos-universal',
-            'ext': 'tar.gz'
-        }
-        install_cmake(**install_cmake_args)
-        add_path(os.path.join(install_dir, 'cmake', 'CMake.app', 'Contents', 'bin'))
+        # Sora, Boost, Lyra, CMake
+        if local_sora:
+            build_sora()
+        else:
+            install_sora_and_deps(source_dir, build_dir, install_dir)
 
         # SDL2
         install_sdl2_args = {
@@ -97,16 +70,6 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_sdl2(**install_sdl2_args)
 
-        # Sora C++ SDK
-        install_sora_args = {
-            'version': version['SORA_CPP_SDK_VERSION'],
-            'version_file': os.path.join(install_dir, 'sora.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'platform': 'macos_arm64',
-        }
-        install_sora(**install_sora_args)
-
         # CLI11
         install_cli11_args = {
             'version': version['CLI11_VERSION'],
@@ -119,6 +82,7 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
+    parser.add_argument("--local-sora", default="")
 
     args = parser.parse_args()
 
@@ -131,7 +95,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.local_sora)
 
     configuration = 'Debug' if args.debug else 'Release'
 
@@ -140,13 +104,18 @@ def main():
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
 
+        if args.local_sora:
+            sora_info = os.path.join(args.local_sora, '_install', dir, configuration_dir)
+        else:
+            sora_info = get_sora_info(install_dir)
+
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
-        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
-        cmake_args.append(f"-DLYRA_DIR={cmake_path(os.path.join(install_dir, 'lyra'))}")
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
+        cmake_args.append(f"-DLYRA_DIR={cmake_path(sora_info.lyra_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
-        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(sora_info.sora_install_dir)}")
         cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
         cmake_args.append(f"-DSDL2_DIR={cmake_path(os.path.join(install_dir, 'sdl2'))}")
 

--- a/sumomo/macos_arm64/run.py
+++ b/sumomo/macos_arm64/run.py
@@ -2,6 +2,7 @@ import os
 import multiprocessing
 import argparse
 import sys
+from typing import Optional, List
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
 sys.path.insert(0, BASE_DIR)
@@ -27,7 +28,7 @@ from base import (  # noqa
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str, sora_args: str):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[str], sora_args: List[str]):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -115,11 +116,7 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
-
-        if args.sora_dir:
-            sora_info = get_sora_info(os.path.join(args.sora_dir, '_install', dir, configuration_dir))
-        else:
-            sora_info = get_sora_info(install_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, configuration_dir)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')

--- a/sumomo/ubuntu-20.04_armv8_jetson/run.py
+++ b/sumomo/ubuntu-20.04_armv8_jetson/run.py
@@ -3,6 +3,7 @@ import multiprocessing
 import argparse
 import sys
 import hashlib
+from typing import Optional, List
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
 sys.path.insert(0, BASE_DIR)
@@ -29,7 +30,7 @@ from base import (  # noqa
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str, sora_args: str):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[str], sora_args: List[str]):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -159,11 +160,7 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
-
-        if args.sora_dir:
-            sora_info = get_sora_info(os.path.join(args.sora_dir, '_install', dir, configuration_dir))
-        else:
-            sora_info = get_sora_info(install_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, configuration_dir)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')

--- a/sumomo/ubuntu-20.04_armv8_jetson/run.py
+++ b/sumomo/ubuntu-20.04_armv8_jetson/run.py
@@ -83,7 +83,7 @@ def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str):
 
         # Sora C++ SDK, Boost, Lyra
         if sora_dir:
-            build_sora('ubuntu-20.04_armv8_jetson', sora_dir)
+            build_sora('ubuntu-20.04_armv8_jetson', sora_dir, debug)
         else:
             install_sora_and_deps('ubuntu-20.04_armv8_jetson', source_dir, build_dir, install_dir)
 

--- a/sumomo/ubuntu-20.04_armv8_jetson/run.py
+++ b/sumomo/ubuntu-20.04_armv8_jetson/run.py
@@ -84,10 +84,10 @@ def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[s
         install_llvm(**install_llvm_args)
 
         # Sora C++ SDK, Boost, Lyra
-        if sora_dir:
-            build_sora('ubuntu-20.04_armv8_jetson', sora_dir, sora_args, debug)
-        else:
+        if sora_dir is None:
             install_sora_and_deps('ubuntu-20.04_armv8_jetson', source_dir, build_dir, install_dir)
+        else:
+            build_sora('ubuntu-20.04_armv8_jetson', sora_dir, sora_args, debug)
 
         # CMake
         install_cmake_args = {
@@ -160,7 +160,7 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
-        sora_info = get_sora_info(install_dir, args.sora_dir, dir, configuration_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, args.debug)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')

--- a/sumomo/ubuntu-20.04_armv8_jetson/run.py
+++ b/sumomo/ubuntu-20.04_armv8_jetson/run.py
@@ -15,20 +15,20 @@ from base import (  # noqa
     add_path,
     cmake_path,
     read_version_file,
+    get_sora_info,
     get_webrtc_info,
     install_rootfs,
     install_webrtc,
     install_llvm,
-    install_boost,
-    install_lyra,
+    build_sora,
+    install_sora_and_deps,
     install_cmake,
     install_sdl2,
-    install_sora,
     install_cli11,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug):
+def install_deps(source_dir, build_dir, install_dir, debug, local_sora: str):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -81,27 +81,11 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_llvm(**install_llvm_args)
 
-        # Boost
-        install_boost_args = {
-            'version': version['BOOST_VERSION'],
-            'version_file': os.path.join(install_dir, 'boost.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-20.04_armv8_jetson',
-        }
-        install_boost(**install_boost_args)
-
-        # Lyra
-        install_lyra_args = {
-            'version': version['LYRA_VERSION'],
-            'version_file': os.path.join(install_dir, 'lyra.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-20.04_armv8_jetson',
-        }
-        install_lyra(**install_lyra_args)
+        # Sora C++ SDK, Boost, Lyra
+        if local_sora:
+            build_sora()
+        else:
+            install_sora_and_deps('ubuntu-20.04_armv8_jetson', source_dir, build_dir, install_dir)
 
         # CMake
         install_cmake_args = {
@@ -141,16 +125,6 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_sdl2(**install_sdl2_args)
 
-        # Sora C++ SDK
-        install_sora_args = {
-            'version': version['SORA_CPP_SDK_VERSION'],
-            'version_file': os.path.join(install_dir, 'sora.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'platform': 'ubuntu-20.04_armv8_jetson',
-        }
-        install_sora(**install_sora_args)
-
         # CLI11
         install_cli11_args = {
             'version': version['CLI11_VERSION'],
@@ -163,6 +137,7 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
+    parser.add_argument("--local-sora", default="")
 
     args = parser.parse_args()
 
@@ -175,7 +150,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.local_sora)
 
     configuration = 'Debug' if args.debug else 'Release'
 
@@ -184,13 +159,18 @@ def main():
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
 
+        if args.local_sora:
+            sora_info = get_sora_info(os.path.join(args.local_sora, '_install', dir, configuration_dir))
+        else:
+            sora_info = get_sora_info(install_dir)
+
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
-        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
-        cmake_args.append(f"-DLYRA_DIR={cmake_path(os.path.join(install_dir, 'lyra'))}")
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
+        cmake_args.append(f"-DLYRA_DIR={cmake_path(sora_info.lyra_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
-        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(sora_info.sora_install_dir)}")
         cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
         cmake_args.append(f"-DSDL2_DIR={cmake_path(os.path.join(install_dir, 'sdl2'))}")
 

--- a/sumomo/ubuntu-20.04_armv8_jetson/run.py
+++ b/sumomo/ubuntu-20.04_armv8_jetson/run.py
@@ -28,7 +28,7 @@ from base import (  # noqa
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug, local_sora: str):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -82,8 +82,8 @@ def install_deps(source_dir, build_dir, install_dir, debug, local_sora: str):
         install_llvm(**install_llvm_args)
 
         # Sora C++ SDK, Boost, Lyra
-        if local_sora:
-            build_sora()
+        if sora_dir:
+            build_sora('ubuntu-20.04_armv8_jetson', sora_dir)
         else:
             install_sora_and_deps('ubuntu-20.04_armv8_jetson', source_dir, build_dir, install_dir)
 
@@ -137,7 +137,7 @@ def install_deps(source_dir, build_dir, install_dir, debug, local_sora: str):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
-    parser.add_argument("--local-sora", default="")
+    parser.add_argument("--sora-dir", default="")
 
     args = parser.parse_args()
 
@@ -150,7 +150,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug, args.local_sora)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir)
 
     configuration = 'Debug' if args.debug else 'Release'
 
@@ -159,8 +159,8 @@ def main():
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
 
-        if args.local_sora:
-            sora_info = get_sora_info(os.path.join(args.local_sora, '_install', dir, configuration_dir))
+        if args.sora_dir:
+            sora_info = get_sora_info(os.path.join(args.sora_dir, '_install', dir, configuration_dir))
         else:
             sora_info = get_sora_info(install_dir)
 

--- a/sumomo/ubuntu-20.04_armv8_jetson/run.py
+++ b/sumomo/ubuntu-20.04_armv8_jetson/run.py
@@ -25,10 +25,11 @@ from base import (  # noqa
     install_cmake,
     install_sdl2,
     install_cli11,
+    add_sora_arguments,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str, sora_args: str):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -83,7 +84,7 @@ def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str):
 
         # Sora C++ SDK, Boost, Lyra
         if sora_dir:
-            build_sora('ubuntu-20.04_armv8_jetson', sora_dir, debug)
+            build_sora('ubuntu-20.04_armv8_jetson', sora_dir, sora_args, debug)
         else:
             install_sora_and_deps('ubuntu-20.04_armv8_jetson', source_dir, build_dir, install_dir)
 
@@ -137,7 +138,7 @@ def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
-    parser.add_argument("--sora-dir", default="")
+    add_sora_arguments(parser)
 
     args = parser.parse_args()
 
@@ -150,7 +151,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir, args.sora_args)
 
     configuration = 'Debug' if args.debug else 'Release'
 

--- a/sumomo/ubuntu-20.04_x86_64/run.py
+++ b/sumomo/ubuntu-20.04_x86_64/run.py
@@ -2,6 +2,7 @@ import os
 import multiprocessing
 import argparse
 import sys
+from typing import Optional, List
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
 sys.path.insert(0, BASE_DIR)
@@ -15,18 +16,19 @@ from base import (  # noqa
     cmake_path,
     read_version_file,
     get_webrtc_info,
+    get_sora_info,
     install_webrtc,
     install_llvm,
-    install_boost,
-    install_lyra,
+    build_sora,
+    install_sora_and_deps,
     install_cmake,
     install_sdl2,
-    install_sora,
     install_cli11,
+    add_sora_arguments,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[str], sora_args: List[str]):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -66,27 +68,12 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_llvm(**install_llvm_args)
 
-        # Boost
-        install_boost_args = {
-            'version': version['BOOST_VERSION'],
-            'version_file': os.path.join(install_dir, 'boost.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-20.04_x86_64',
-        }
-        install_boost(**install_boost_args)
+        # Sora C++ SDK, Boost, Lyra
+        if sora_dir is None:
+            install_sora_and_deps('ubuntu-20.04_x86_64', source_dir, build_dir, install_dir)
+        else:
+            build_sora('ubuntu-20.04_x86_64', sora_dir, sora_args, debug)
 
-        # Lyra
-        install_lyra_args = {
-            'version': version['LYRA_VERSION'],
-            'version_file': os.path.join(install_dir, 'lyra.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-20.04_x86_64',
-        }
-        install_lyra(**install_lyra_args)
 
         # CMake
         install_cmake_args = {
@@ -116,16 +103,6 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_sdl2(**install_sdl2_args)
 
-        # Sora C++ SDK
-        install_sora_args = {
-            'version': version['SORA_CPP_SDK_VERSION'],
-            'version_file': os.path.join(install_dir, 'sora.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'platform': 'ubuntu-20.04_x86_64',
-        }
-        install_sora(**install_sora_args)
-
         # CLI11
         install_cli11_args = {
             'version': version['CLI11_VERSION'],
@@ -138,6 +115,7 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
+    add_sora_arguments(parser)
 
     args = parser.parse_args()
 
@@ -150,7 +128,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir, args.sora_args)
 
     configuration = 'Debug' if args.debug else 'Release'
 
@@ -158,14 +136,15 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, args.debug)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
-        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
-        cmake_args.append(f"-DLYRA_DIR={cmake_path(os.path.join(install_dir, 'lyra'))}")
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
+        cmake_args.append(f"-DLYRA_DIR={cmake_path(sora_info.lyra_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
-        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(sora_info.sora_install_dir)}")
         cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
         cmake_args.append(f"-DSDL2_DIR={cmake_path(os.path.join(install_dir, 'sdl2'))}")
 

--- a/sumomo/ubuntu-22.04_x86_64/run.py
+++ b/sumomo/ubuntu-22.04_x86_64/run.py
@@ -2,6 +2,7 @@ import os
 import multiprocessing
 import argparse
 import sys
+from typing import Optional, List
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
 sys.path.insert(0, BASE_DIR)
@@ -14,19 +15,20 @@ from base import (  # noqa
     add_path,
     cmake_path,
     read_version_file,
+    get_sora_info,
     get_webrtc_info,
     install_webrtc,
     install_llvm,
-    install_boost,
-    install_lyra,
+    build_sora,
+    install_sora_and_deps,
     install_cmake,
     install_sdl2,
-    install_sora,
     install_cli11,
+    add_sora_arguments,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[str], sora_args: List[str]):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -66,27 +68,12 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_llvm(**install_llvm_args)
 
-        # Boost
-        install_boost_args = {
-            'version': version['BOOST_VERSION'],
-            'version_file': os.path.join(install_dir, 'boost.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-22.04_x86_64',
-        }
-        install_boost(**install_boost_args)
+        # Sora C++ SDK, Boost, Lyra
+        if sora_dir is None:
+            install_sora_and_deps('ubuntu-22.04_x86_64', source_dir, build_dir, install_dir)
+        else:
+            build_sora('ubuntu-22.04_x86_64', sora_dir, sora_args, debug)
 
-        # Lyra
-        install_lyra_args = {
-            'version': version['LYRA_VERSION'],
-            'version_file': os.path.join(install_dir, 'lyra.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'ubuntu-22.04_x86_64',
-        }
-        install_lyra(**install_lyra_args)
 
         # CMake
         install_cmake_args = {
@@ -116,16 +103,6 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_sdl2(**install_sdl2_args)
 
-        # Sora C++ SDK
-        install_sora_args = {
-            'version': version['SORA_CPP_SDK_VERSION'],
-            'version_file': os.path.join(install_dir, 'sora.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'platform': 'ubuntu-22.04_x86_64',
-        }
-        install_sora(**install_sora_args)
-
         # CLI11
         install_cli11_args = {
             'version': version['CLI11_VERSION'],
@@ -138,6 +115,7 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
+    add_sora_arguments(parser)
 
     args = parser.parse_args()
 
@@ -150,7 +128,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir, args.sora_args)
 
     configuration = 'Debug' if args.debug else 'Release'
 
@@ -158,14 +136,15 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, args.debug)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
-        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
-        cmake_args.append(f"-DLYRA_DIR={cmake_path(os.path.join(install_dir, 'lyra'))}")
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
+        cmake_args.append(f"-DLYRA_DIR={cmake_path(sora_info.lyra_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
-        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(sora_info.sora_install_dir)}")
         cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
         cmake_args.append(f"-DSDL2_DIR={cmake_path(os.path.join(install_dir, 'sdl2'))}")
 

--- a/sumomo/windows_x86_64/run.py
+++ b/sumomo/windows_x86_64/run.py
@@ -2,6 +2,7 @@ import os
 import multiprocessing
 import argparse
 import sys
+from typing import Optional, List
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.join(PROJECT_DIR, '..', '..')
 sys.path.insert(0, BASE_DIR)
@@ -26,7 +27,7 @@ from base import (  # noqa
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str, sora_args: str):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[str], sora_args: List[str]):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -110,11 +111,7 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
-
-        if args.sora_dir:
-            sora_info = get_sora_info(os.path.join(args.sora_dir, '_install', dir, configuration_dir))
-        else:
-            sora_info = get_sora_info(install_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, configuration_dir)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')

--- a/sumomo/windows_x86_64/run.py
+++ b/sumomo/windows_x86_64/run.py
@@ -25,7 +25,7 @@ from base import (  # noqa
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug, local_sora: str):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -41,8 +41,8 @@ def install_deps(source_dir, build_dir, install_dir, debug, local_sora: str):
         install_webrtc(**install_webrtc_args)
 
         # Sora C++ SDK, Boost, Lyra
-        if local_sora:
-            build_sora()
+        if sora_dir:
+            build_sora('windows_x86_64'. sora_dir)
         else:
             install_sora_and_deps('windows_x86_64', source_dir, build_dir, install_dir)
 
@@ -84,7 +84,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
     parser.add_argument("--relwithdebinfo", action='store_true')
-    parser.add_argument("--local-sora", default="")
+    parser.add_argument("--sora-dir", default="")
 
     args = parser.parse_args()
 
@@ -97,7 +97,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug, args.local_sora)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir)
 
     configuration = 'Release'
     if args.debug:
@@ -110,8 +110,8 @@ def main():
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
 
-        if args.local_sora:
-            sora_info = get_sora_info(os.path.join(args.local_sora, '_install', dir, configuration_dir))
+        if args.sora_dir:
+            sora_info = get_sora_info(os.path.join(args.sora_dir, '_install', dir, configuration_dir))
         else:
             sora_info = get_sora_info(install_dir)
 

--- a/sumomo/windows_x86_64/run.py
+++ b/sumomo/windows_x86_64/run.py
@@ -42,7 +42,7 @@ def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str):
 
         # Sora C++ SDK, Boost, Lyra
         if sora_dir:
-            build_sora('windows_x86_64'. sora_dir)
+            build_sora('windows_x86_64'. sora_dir, debug)
         else:
             install_sora_and_deps('windows_x86_64', source_dir, build_dir, install_dir)
 

--- a/sumomo/windows_x86_64/run.py
+++ b/sumomo/windows_x86_64/run.py
@@ -22,10 +22,11 @@ from base import (  # noqa
     install_cmake,
     install_sdl2,
     install_cli11,
+    add_sora_arguments,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str):
+def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str, sora_args: str):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -42,7 +43,7 @@ def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: str):
 
         # Sora C++ SDK, Boost, Lyra
         if sora_dir:
-            build_sora('windows_x86_64'. sora_dir, debug)
+            build_sora('windows_x86_64'. sora_dir, sora_args, debug)
         else:
             install_sora_and_deps('windows_x86_64', source_dir, build_dir, install_dir)
 
@@ -84,7 +85,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
     parser.add_argument("--relwithdebinfo", action='store_true')
-    parser.add_argument("--sora-dir", default="")
+    add_sora_arguments(parser)
 
     args = parser.parse_args()
 
@@ -97,7 +98,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.sora_dir, args.sora_args)
 
     configuration = 'Release'
     if args.debug:

--- a/sumomo/windows_x86_64/run.py
+++ b/sumomo/windows_x86_64/run.py
@@ -14,18 +14,18 @@ from base import (  # noqa
     add_path,
     cmake_path,
     read_version_file,
+    get_sora_info,
     get_webrtc_info,
     install_webrtc,
-    install_boost,
-    install_lyra,
+    build_sora,
+    install_sora_and_deps,
     install_cmake,
     install_sdl2,
-    install_sora,
     install_cli11,
 )
 
 
-def install_deps(source_dir, build_dir, install_dir, debug):
+def install_deps(source_dir, build_dir, install_dir, debug, local_sora: str):
     with cd(BASE_DIR):
         version = read_version_file('VERSION')
 
@@ -40,27 +40,11 @@ def install_deps(source_dir, build_dir, install_dir, debug):
 
         install_webrtc(**install_webrtc_args)
 
-        # Boost
-        install_boost_args = {
-            'version': version['BOOST_VERSION'],
-            'version_file': os.path.join(install_dir, 'boost.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'windows_x86_64',
-        }
-        install_boost(**install_boost_args)
-
-        # Lyra
-        install_lyra_args = {
-            'version': version['LYRA_VERSION'],
-            'version_file': os.path.join(install_dir, 'lyra.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'sora_version': version['SORA_CPP_SDK_VERSION'],
-            'platform': 'windows_x86_64',
-        }
-        install_lyra(**install_lyra_args)
+        # Sora C++ SDK, Boost, Lyra
+        if local_sora:
+            build_sora()
+        else:
+            install_sora_and_deps('windows_x86_64', source_dir, build_dir, install_dir)
 
         # CMake
         install_cmake_args = {
@@ -72,7 +56,6 @@ def install_deps(source_dir, build_dir, install_dir, debug):
             'ext': 'zip'
         }
         install_cmake(**install_cmake_args)
-
         add_path(os.path.join(install_dir, 'cmake', 'bin'))
 
         # SDL2
@@ -88,16 +71,6 @@ def install_deps(source_dir, build_dir, install_dir, debug):
         }
         install_sdl2(**install_sdl2_args)
 
-        # Sora C++ SDK
-        install_sora_args = {
-            'version': version['SORA_CPP_SDK_VERSION'],
-            'version_file': os.path.join(install_dir, 'sora.version'),
-            'source_dir': source_dir,
-            'install_dir': install_dir,
-            'platform': 'windows_x86_64',
-        }
-        install_sora(**install_sora_args)
-
         # CLI11
         install_cli11_args = {
             'version': version['CLI11_VERSION'],
@@ -111,6 +84,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action='store_true')
     parser.add_argument("--relwithdebinfo", action='store_true')
+    parser.add_argument("--local-sora", default="")
 
     args = parser.parse_args()
 
@@ -123,7 +97,7 @@ def main():
     mkdir_p(build_dir)
     mkdir_p(install_dir)
 
-    install_deps(source_dir, build_dir, install_dir, args.debug)
+    install_deps(source_dir, build_dir, install_dir, args.debug, args.local_sora)
 
     configuration = 'Release'
     if args.debug:
@@ -136,13 +110,18 @@ def main():
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
 
+        if args.local_sora:
+            sora_info = get_sora_info(os.path.join(args.local_sora, '_install', dir, configuration_dir))
+        else:
+            sora_info = get_sora_info(install_dir)
+
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')
-        cmake_args.append(f"-DBOOST_ROOT={cmake_path(os.path.join(install_dir, 'boost'))}")
-        cmake_args.append(f"-DLYRA_DIR={cmake_path(os.path.join(install_dir, 'lyra'))}")
+        cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
+        cmake_args.append(f"-DLYRA_DIR={cmake_path(sora_info.lyra_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")
-        cmake_args.append(f"-DSORA_DIR={cmake_path(os.path.join(install_dir, 'sora'))}")
+        cmake_args.append(f"-DSORA_DIR={cmake_path(sora_info.sora_install_dir)}")
         cmake_args.append(f"-DCLI11_DIR={cmake_path(os.path.join(install_dir, 'cli11'))}")
         cmake_args.append(f"-DSDL2_DIR={cmake_path(os.path.join(install_dir, 'sdl2'))}")
         cmd(['cmake', os.path.join(PROJECT_DIR)] + cmake_args)

--- a/sumomo/windows_x86_64/run.py
+++ b/sumomo/windows_x86_64/run.py
@@ -43,10 +43,10 @@ def install_deps(source_dir, build_dir, install_dir, debug, sora_dir: Optional[s
         install_webrtc(**install_webrtc_args)
 
         # Sora C++ SDK, Boost, Lyra
-        if sora_dir:
-            build_sora('windows_x86_64'. sora_dir, sora_args, debug)
-        else:
+        if sora_dir is  None:
             install_sora_and_deps('windows_x86_64', source_dir, build_dir, install_dir)
+        else:
+            build_sora('windows_x86_64'. sora_dir, sora_args, debug)
 
         # CMake
         install_cmake_args = {
@@ -111,7 +111,7 @@ def main():
     mkdir_p(sample_build_dir)
     with cd(sample_build_dir):
         webrtc_info = get_webrtc_info(False, source_dir, build_dir, install_dir)
-        sora_info = get_sora_info(install_dir, args.sora_dir, dir, configuration_dir)
+        sora_info = get_sora_info(install_dir, args.sora_dir, dir, args.debug)
 
         cmake_args = []
         cmake_args.append(f'-DCMAKE_BUILD_TYPE={configuration}')


### PR DESCRIPTION
## 変更内容

- 標題の機能を実現するため、ビルド・スクリプトに以下のオプションを追加しました
  - `--sora-dir` ... ローカルの Sora C++ SDK のパスを絶対パスで指定します。 Sora C++ SDK はビルドされます。
  - `--sora-args` ... ローカルの Sora C++ SDK をビルドする際のオプションを指定します

## 残タスク

sumomo の macos_arm64, windows_x86_64, ubuntu-20.04_armv8_jetson のみ対応しています。
方針に問題が無いかレビューを受けた後、他のサンプル/プラットフォームの対応 & ドキュメンテーションを行います。

## 現状把握している課題

`--sora-args` でオプションを指定する際に `=` を使用しないと正しく認識されません

```
# OK
$ python3 sumomo/macos_arm64/run.py --sora-dir $HOME/github.com/shiguredo/hoge/sora-cpp-sdk --sora-args='--test'

# NG
$ python3 sumomo/macos_arm64/run.py --sora-dir $HOME/github.com/shiguredo/hoge/sora-cpp-sdk --sora-args '--test'
usage: run.py [-h] [--debug] [--sora-dir SORA_DIR] [--sora-args SORA_ARGS]
run.py: error: argument --sora-args: expected one argument
```

---

This pull request primarily focuses on refactoring the way dependencies are handled in the build scripts for the `messaging_recvonly_sample` project across different platforms. The changes aim to improve code reusability and maintainability by introducing a new function `install_sora_and_deps`, which installs the Sora C++ SDK, Boost, and Lyra. If a directory for Sora is provided, the function `build_sora` is used instead. The new `SoraInfo` class is introduced to store information about the installation directories of these dependencies.

The most important changes are:

**Changes to `base.py`:**

* Imported the `shlex` module.
* Added a new class `SoraInfo` to hold the installation directories of Sora, Boost, and Lyra.
* Added new functions `install_sora_and_deps`, `add_sora_arguments`, `build_sora`, and `get_sora_info` to handle the installation of Sora and its dependencies.

**Changes to `messaging_recvonly_sample` scripts:**

* Imported `Optional` and `List` from the `typing` module and the new functions from `base.py` in all the `run.py` scripts. [[1]](diffhunk://#diff-875562cbde91176f1a2345c2b5af4da9c5c01402bb265cf94065b9b1af94f7d4R5) [[2]](diffhunk://#diff-362f7c86fb12c4463e2ed6ae063339b27f681d55cf3cbb3b6c93ff1690f23c9fR6) [[3]](diffhunk://#diff-71be74e9400c9082715466e62ebb5a4e79101dd5bcbceff935718f06184dc182R5) [[4]](diffhunk://#diff-167d1578e7e162177a0ed7088e172e700607a5302d6ba4081468befd2ff23326R5)
* Refactored the `install_deps` function in all the `run.py` scripts to use `install_sora_and_deps` or `build_sora` instead of installing Boost, Lyra, and Sora separately. [[1]](diffhunk://#diff-875562cbde91176f1a2345c2b5af4da9c5c01402bb265cf94065b9b1af94f7d4R19-R30) [[2]](diffhunk://#diff-362f7c86fb12c4463e2ed6ae063339b27f681d55cf3cbb3b6c93ff1690f23c9fR19-R32) [[3]](diffhunk://#diff-71be74e9400c9082715466e62ebb5a4e79101dd5bcbceff935718f06184dc182R18-R31) [[4]](diffhunk://#diff-167d1578e7e162177a0ed7088e172e700607a5302d6ba4081468befd2ff23326R18-R30)
* Added `add_sora_arguments` to the argument parser in the `main` function of all the `run.py` scripts. [[1]](diffhunk://#diff-875562cbde91176f1a2345c2b5af4da9c5c01402bb265cf94065b9b1af94f7d4R74) [[2]](diffhunk://#diff-362f7c86fb12c4463e2ed6ae063339b27f681d55cf3cbb3b6c93ff1690f23c9fR114) [[3]](diffhunk://#diff-71be74e9400c9082715466e62ebb5a4e79101dd5bcbceff935718f06184dc182R100) F6baab7bL133R110)
* Modified the `main` function in all the `run.py` scripts to use `get_sora_info` and pass the installation directories to `cmake_args`. [[1]](diffhunk://#diff-875562cbde91176f1a2345c2b5af4da9c5c01402bb265cf94065b9b1af94f7d4L110-R103) [[2]](diffhunk://#diff-362f7c86fb12c4463e2ed6ae063339b27f681d55cf3cbb3b6c93ff1690f23c9fL150-R143) [[3]](diffhunk://#diff-71be74e9400c9082715466e62ebb5a4e79101dd5bcbceff935718f06184dc182L136-R129) F6baab7bL147R134)