### PR TITLE
sdl_sample の audio_codec_lyra_bitrate を 0 で初期化する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,11 @@
   - SDL2 を 2.30.0 にあげる
   - CLI11 を v2.4.1 にあげる
   - @miosakuma @enm10k
+- [FIX] sdl_sample で `--audio-codec-lyra-bitrate` が未指定の時に不定な値が送信されるのを修正する
+  - SDLSampleConfig.audio_codec_lyra_bitrate の値が初期化されておらず、未指定の時に不定な値が送信されるようになっていた
+    - SDLSampleConfig.audio_codec_lyra_bitrate の初期値を 0 に設定する
+    - 値が 0 の時、Sora に値は送信されない
+  - @miosakuma
 
 ## sora-cpp-sdk-2023.17.0
 

--- a/sdl_sample/src/sdl_sample.cpp
+++ b/sdl_sample/src/sdl_sample.cpp
@@ -22,7 +22,7 @@ struct SDLSampleConfig {
   std::string role;
   std::string video_codec_type;
   std::string audio_codec_type;
-  int audio_codec_lyra_bitrate;
+  int audio_codec_lyra_bitrate = 0;
   boost::optional<bool> audio_codec_lyra_usedtx;
   boost::optional<bool> multistream;
   int width = 640;


### PR DESCRIPTION
sdl_sample で 以下のパラメータを指定した時に Sora 側のチェックでエラーとなってしまう問題があり修正しました。

- `--audio-codec-type` に `LYRA` を指定
- `--audio-codec-lyra-bitrate` 未指定

SDLSampleConfig.audio_codec_lyra_bitrate が初期化されていないのが原因であったため 0 を指定しています。0 の場合 Sora に値は送信されません。
https://github.com/shiguredo/sora-cpp-sdk/blob/03db60386053b809a8b74f91dd2bd999e30605d0/src/sora_signaling.cpp#L401-L403

macOS 環境で動作確認済みです。

---

This pull request includes important changes to the `sdl_sample` code and the `CHANGES.md` file. The primary change is the initialization of `SDLSampleConfig.audio_codec_lyra_bitrate` to 0 in `sdl_sample/src/sdl_sample.cpp` to prevent undefined values from being sent when `--audio-codec-lyra-bitrate` is unspecified. The `CHANGES.md` file has been updated to reflect this fix.

Key changes include:

* [`sdl_sample/src/sdl_sample.cpp`](diffhunk://#diff-91cb96a770dc6d1f2883b38e718ac2086112612af039f91c90c2d25cf75d7b01L25-R25): Initialized `SDLSampleConfig.audio_codec_lyra_bitrate` to 0 to prevent undefined values from being sent when `--audio-codec-lyra-bitrate` is not specified.
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R25-R29): Added a fix entry to document the change made in `SDLSampleConfig.audio_codec_lyra_bitrate`.
