### PR TITLE
setup-msbuild と upload-artifact のバージョンを上げる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v4
-      - uses: microsoft/setup-msbuild@v1.1
+      - uses: microsoft/setup-msbuild@v2
       - run: python3 sdl_sample/${{ matrix.name }}/run.py
       - run: python3 sumomo/${{ matrix.name }}/run.py
       - run: python3 messaging_recvonly_sample/${{ matrix.name }}/run.py
@@ -30,7 +30,7 @@ jobs:
           cp _build\${{ matrix.name }}\release\sumomo\Release\sumomo.exe ${{ matrix.name }}
           cp _build\${{ matrix.name }}\release\messaging_recvonly_sample\Release\messaging_recvonly_sample.exe ${{ matrix.name }}
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.name }}
@@ -54,7 +54,7 @@ jobs:
           cp _build/${{ matrix.name }}/release/sumomo/sumomo ${{ matrix.name }}
           cp _build/${{ matrix.name }}/release/messaging_recvonly_sample/messaging_recvonly_sample ${{ matrix.name }}
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.name }}
@@ -91,7 +91,7 @@ jobs:
           cp _build/${{ matrix.name }}/release/sumomo/sumomo ${{ matrix.name }}
           cp _build/${{ matrix.name }}/release/messaging_recvonly_sample/messaging_recvonly_sample ${{ matrix.name }}
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.name }}
@@ -120,7 +120,7 @@ jobs:
           cp _build/${{ matrix.name }}/release/sumomo/sumomo ${{ matrix.name }}
           cp _build/${{ matrix.name }}/release/messaging_recvonly_sample/messaging_recvonly_sample ${{ matrix.name }}
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.name }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,10 @@
 - [UPDATE] VERSION のライブラリをアップデートする
   - SORA_CPP_SDK_VERSION を 2024.3.1 にあげる
   - @enm10k
+- [UPDATE] Github Actions の setup-msbuild と upload-artifact のバージョンをアップデート
+  - Node.js 16 の Deprecated に伴う対応
+    - setup-msbuild を 1.1 から 2 にアップデート
+    - upload-artifact を 3 から 4 にアップデート
 
 ## sora-cpp-sdk-2024.2.0
 


### PR DESCRIPTION
Actions が通れば問題なしです。

----

This pull request primarily updates the versions of certain actions used in the GitHub workflow, specifically `setup-msbuild` and `upload-artifact`. These changes are made in the `.github/workflows/build.yml` file. Additionally, the `CHANGES.md` file is updated to reflect these version updates.

Version updates in GitHub workflow:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L22-R22): The version of `setup-msbuild` action is updated from `v1.1` to `v2`.
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L33-R33): The version of `upload-artifact` action is updated from `v3` to `v4` in multiple job steps [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L33-R33) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L57-R57) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L94-R94) [[4]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L123-R123).

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R23-R26): The changes in the versions of `setup-msbuild` and `upload-artifact` are documented.